### PR TITLE
feat(dx): Drop min. Xcode version from 13.0 to 12.0

### DIFF
--- a/Sources/AmplifyMapLibreAdapter/Extensions/MGLPointFeature+Geo.Place.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/MGLPointFeature+Geo.Place.swift
@@ -96,29 +96,29 @@ public extension Geo.Place {
 fileprivate extension Dictionary where Key == String, Value == Any {
     private func placeKey<T>(for keyPath: KeyPath<Geo.Place, T>) -> String {
         switch keyPath {
-        case \.street: return "aml_geo.place_street"
-        case \.addressNumber: return "aml_geo.place_addressNumber"
-        case \.label: return "aml_geo.place_label"
-        case \.country: return "aml_geo.place_country"
-        case \.municipality: return "aml_geo.place_municipality"
-        case \.neighborhood: return "aml_geo.place_neighborhood"
-        case \.postalCode: return "aml_geo.place_postalCode"
-        case \.region: return "aml_geo.place_region"
-        case \.subRegion: return "aml_geo.place_subRegion"
+        case \Geo.Place.street: return "aml_geo.place_street"
+        case \Geo.Place.addressNumber: return "aml_geo.place_addressNumber"
+        case \Geo.Place.label: return "aml_geo.place_label"
+        case \Geo.Place.country: return "aml_geo.place_country"
+        case \Geo.Place.municipality: return "aml_geo.place_municipality"
+        case \Geo.Place.neighborhood: return "aml_geo.place_neighborhood"
+        case \Geo.Place.postalCode: return "aml_geo.place_postalCode"
+        case \Geo.Place.region: return "aml_geo.place_region"
+        case \Geo.Place.subRegion: return "aml_geo.place_subRegion"
         default: return "aml_geo.place_default"
         }
     }
 
     subscript<T>(_ placeKeyPath: KeyPath<Geo.Place, T>) -> T? {
         get {
-            if placeKeyPath ~= \.coordinates {
+            if placeKeyPath ~= \Geo.Place.coordinates {
                 return getCoordinate() as? T
             }
             let key = placeKey(for: placeKeyPath)
             return self[key] as? T
         }
         set {
-            if placeKeyPath ~= \.coordinates {
+            if placeKeyPath ~= \Geo.Place.coordinates {
                 setCoordinate(newValue)
                 return
             }

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
@@ -58,7 +58,7 @@ internal class AMLMapViewSettings: ObservableObject {
         maxZoomLevel: Double = 22,
         hideAttributionButton: Bool = false,
         compassPosition: MGLOrnamentPosition = .bottomLeft,
-        featureImage: UIImage = .init(
+        featureImage: UIImage = UIImage(
             named: "AMLFeatureView",
             in: Bundle.module,
             compatibleWith: nil

--- a/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper+Coordinator.swift
+++ b/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper+Coordinator.swift
@@ -67,7 +67,7 @@ extension _MGLMapViewWrapper.Coordinator {
     ///     - Identifier: `"aml_cluster_number_layer"`
     /// - Parameter style: The `MGLStyle` that the layers will be added to.
     private func setupRenderingLayers(for style: MGLStyle) {
-        let locationSource = locationSource()
+        let locationSource = makeLocationSource()
         style.addSource(locationSource)
         let defaultImage = UIImage(
             named: "AMLFeatureView",
@@ -76,19 +76,19 @@ extension _MGLMapViewWrapper.Coordinator {
         )!
         style.setImage(defaultImage, forName: "aml_feature")
 
-        let featureLayer = featureLayer(for: locationSource)
+        let featureLayer = makeFeatureLayer(for: locationSource)
         style.addLayer(featureLayer)
 
-        let clusterCircleLayer = clusterCircleLayer(for: locationSource)
+        let clusterCircleLayer = makeClusterCircleLayer(for: locationSource)
         style.addLayer(clusterCircleLayer)
 
-        let clusterNumberLayer = clusterNumberLayer(for: locationSource)
+        let clusterNumberLayer = makeClusterNumberLayer(for: locationSource)
         style.addLayer(clusterNumberLayer)
     }
 
     /// Create the location source used to source features in the subsequent layers.
     /// - Returns: A `MGLShapeSource` with defined clustering options.
-    private func locationSource() -> MGLShapeSource {
+    private func makeLocationSource() -> MGLShapeSource {
         MGLShapeSource.init(
             identifier: "aml_location_source",
             shape: nil,
@@ -104,7 +104,7 @@ extension _MGLMapViewWrapper.Coordinator {
     /// Create the layer that renders features on the map.
     /// - Parameter source: The layer's source.
     /// - Returns: A `MGLSymbolStyleLayer` that will render features provided through the `source`.
-    private func featureLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
+    private func makeFeatureLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
         let featureLayer = MGLSymbolStyleLayer(identifier: "aml_feature_style_layer", source: source)
         featureLayer.iconImageName = NSExpression(forConstantValue: "aml_feature")
         featureLayer.iconIgnoresPlacement = NSExpression(forConstantValue: true)
@@ -117,7 +117,7 @@ extension _MGLMapViewWrapper.Coordinator {
     /// - Parameter source: The layer's source. Generally the same as the feature layer's `source`.
     /// - Returns: A `MGLCircleStyleLayer` that will render feature clusters provided through the `source`.
     /// Clustering behavior defined through `ClusteringBehavior`.
-    private func clusterCircleLayer(for source: MGLSource) -> MGLCircleStyleLayer {
+    private func makeClusterCircleLayer(for source: MGLSource) -> MGLCircleStyleLayer {
         let clusterCircleLayer = MGLCircleStyleLayer(identifier: "aml_cluster_circle_layer", source: source)
 
         clusterCircleLayer.circleRadius = NSExpression(
@@ -145,7 +145,7 @@ extension _MGLMapViewWrapper.Coordinator {
     /// Create the layer that renders numbers on the feature clusters on the map.
     /// - Parameter source: The layer's source. Generally the same as the cluster circle layer's `source`.
     /// - Returns: A `MGLSymbolStyleLayer` that renders numbers on feature clusters provided through the `source`.
-    private func clusterNumberLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
+    private func makeClusterNumberLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
         let clusterNumberLayer = MGLSymbolStyleLayer(identifier: "aml_cluster_number_layer", source: source)
         clusterNumberLayer.text = NSExpression(format: "CAST(point_count, 'NSString')")
         clusterNumberLayer.textColor = NSExpression(forConstantValue: control.clusteringBehavior.clusterNumberColor)

--- a/Sources/AmplifyMapLibreUI/SupportingViews/AMLPlaceCellView.swift
+++ b/Sources/AmplifyMapLibreUI/SupportingViews/AMLPlaceCellView.swift
@@ -24,10 +24,10 @@ public struct AMLPlaceCellView: View {
         VStack(alignment: .leading) {
             HStack {
                 Text(place.labelLine ?? "")
-                    .font(.headline.weight(.semibold))
+                    .font(Font.headline.weight(Font.Weight.semibold))
                 Spacer()
                 Text(place.neighborhood?.uppercased() ?? "")
-                    .font(.footnote.weight(.light))
+                    .font(Font.footnote.weight(Font.Weight.light))
                     .foregroundColor(.secondary)
             }
             Text(addressLine(for: place))

--- a/Sources/AmplifyMapLibreUI/SupportingViews/AMLSearchBar.swift
+++ b/Sources/AmplifyMapLibreUI/SupportingViews/AMLSearchBar.swift
@@ -149,7 +149,7 @@ private struct AMLSearchBarIconOverlay: View {
                     endEditing()
                 }, label: {
                     Image(systemName: "multiply")
-                        .font(.body.weight(.medium))
+                        .font(Font.body.weight(.medium))
                         .foregroundColor(.primary)
                         .padding(.trailing, 8)
                 })
@@ -162,7 +162,7 @@ private struct AMLSearchBarIconOverlay: View {
                     endEditing()
                 } label: {
                     Image(systemName: displayState.imageName)
-                        .font(.body.weight(.medium))
+                        .font(Font.body.weight(.medium))
                         .foregroundColor(.primary)
                         .padding(.trailing, 8)
                 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
No functional changes. This PR drops the internal usage of Swift >5.3 language features in order to support Xcode 12.

*Check points: (check or cross out if not relevant)*

- [x] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [x] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all targets using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Documentation update for the change if required~ (Amplify docs change will be made after merge)
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
