### PR TITLE
fix(UI): Add proper attribution mechanism

### DIFF
--- a/HostApp/HostApp.xcodeproj/project.pbxproj
+++ b/HostApp/HostApp.xcodeproj/project.pbxproj
@@ -153,8 +153,8 @@
 			isa = PBXGroup;
 			children = (
 				90E379FC2746E6B2006FC938 /* AMLMapView_ViewModel.swift */,
-				90E379FD2746E6B2006FC938 /* SimpleAMLMapView_View.swift */,
 				90E379FE2746E6B2006FC938 /* AMLMapView_View.swift */,
+				90E379FD2746E6B2006FC938 /* SimpleAMLMapView_View.swift */,
 				90E379FF2746E6B2006FC938 /* AMLMapCompositeView_View.swift */,
 			);
 			path = Views;

--- a/HostApp/HostApp/HostAppApp.swift
+++ b/HostApp/HostApp/HostAppApp.swift
@@ -15,8 +15,6 @@ struct HostAppApp: App {
 
     var body: some Scene {
         WindowGroup {
-//            SimpleAMLMapView_View()
-//            AMLMapView_View()
             AMLMapCompositeView_View()
         }
     }

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapAttributionView.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapAttributionView.swift
@@ -1,0 +1,48 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SwiftUI
+
+/// Internal AttributionView for AMLMap
+struct AMLMapAttributionView: View {
+
+    @Binding var isAttributionTextDisplayed: Bool
+    let attributionText: String?
+
+    var body: some View {
+        if  isAttributionTextDisplayed {
+            Text(attributionText ?? "MapLibre Maps SDK for iOS")
+                .font(.system(size: 12))
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.center)
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12.5)
+                        .fill(Color.white)
+                )
+                .onTapGesture {
+                    isAttributionTextDisplayed.toggle()
+                }
+                .padding()
+                .padding(.bottom)
+        } else {
+            HStack {
+                Spacer()
+                Button {
+                    isAttributionTextDisplayed.toggle()
+                } label: {
+                    Image(systemName: "info.circle")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 22, height: 22)
+                        .padding()
+                        .padding(.bottom)
+                }
+            }
+        }
+    }
+}

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
@@ -49,25 +49,36 @@ public struct AMLMapView: View {
     public var body: some View {
         switch mapLoadingState.state {
         case .complete(let mapView):
-            _MGLMapViewWrapper(
-                mapView: mapView,
-                zoomLevel: $mapState.zoomLevel,
-                bounds: $mapState.bounds,
-                center: $mapState.center,
-                heading: $mapState.heading,
-                userLocation: $mapState.userLocation,
-                showUserLocation: mapSettings.showUserLocation,
-                features: $mapState.features,
-                attribution: $mapState.attribution,
-                featureImage: mapSettings.featureImage,
-                clusteringBehavior: mapSettings.clusteringBehavior,
-                proxyDelegate: mapSettings.proxyDelegate
-            )
-                .showUserLocation(mapSettings.showUserLocation)
-                .compassPosition(mapSettings.compassPosition)
-                .minZoomLevel(mapSettings.minZoomLevel)
-                .maxZoomLevel(mapSettings.maxZoomLevel)
-                .hideAttributionButton(mapSettings.hideAttributionButton)
+            ZStack {
+                _MGLMapViewWrapper(
+                    mapView: mapView,
+                    zoomLevel: $mapState.zoomLevel,
+                    bounds: $mapState.bounds,
+                    center: $mapState.center,
+                    heading: $mapState.heading,
+                    userLocation: $mapState.userLocation,
+                    showUserLocation: mapSettings.showUserLocation,
+                    features: $mapState.features,
+                    attribution: $mapState.attribution,
+                    featureImage: mapSettings.featureImage,
+                    clusteringBehavior: mapSettings.clusteringBehavior,
+                    proxyDelegate: mapSettings.proxyDelegate
+                )
+                    .showUserLocation(mapSettings.showUserLocation)
+                    .compassPosition(mapSettings.compassPosition)
+                    .minZoomLevel(mapSettings.minZoomLevel)
+                    .maxZoomLevel(mapSettings.maxZoomLevel)
+
+                if !mapSettings.hideAttributionButton {
+                    VStack {
+                        Spacer()
+                        AMLMapAttributionView(
+                            isAttributionTextDisplayed: $mapState.isAttributionTextDisplayed,
+                            attributionText: mapState.attribution
+                        )
+                    }
+                }
+            }
         case .error(let error):
             Text("Error loading view: \(error.localizedDescription)")
         case .begin:

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
@@ -35,6 +35,9 @@ public class AMLMapViewState: ObservableObject {
     /// The attribution string for the map data providers.
     @Published public var attribution: String?
 
+    /// Whether the attribution test is currently being displayed.
+    @Published internal(set) public var isAttributionTextDisplayed: Bool
+
     /// Create an `AMLMapViewState` object to track state changes.
     /// - Parameters:
     ///   - mapView: The underlying `MGLMapView`
@@ -69,5 +72,6 @@ public class AMLMapViewState: ObservableObject {
         self.userLocation = userLocation
         self.attribution = attribution
         self.features = features
+        self.isAttributionTextDisplayed = false
     }
 }

--- a/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper+ViewModifiers.swift
@@ -82,14 +82,6 @@ extension _MGLMapViewWrapper {
         return self
     }
 
-    /// Set map's attribution button to hidden or showing.
-    /// - Parameter hide:`true` hides the button / `false` unhides the button
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func hideAttributionButton(_ hide: Bool) -> _MGLMapViewWrapper {
-        mapView.attributionButton.isHidden = hide
-        return self
-    }
-
     /// Set the position of the compass on the `MGLMapView`.
     /// - Parameter position: `MGLOrnamentPosition` defining the location.
     /// - Returns: An instance of `_MGLMapViewWrapper`.

--- a/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper.swift
+++ b/Sources/AmplifyMapLibreUI/MGLMapViewWrapper/_MGLMapViewWrapper.swift
@@ -88,8 +88,8 @@ internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
         self.mapView.zoomLevel = zoomLevel.wrappedValue
         self.mapView.logoView.isHidden = true
         self.mapView.showsUserLocation = showUserLocation || userLocation.wrappedValue != nil
-
         self.mapView.style?.setImage(featureImage, forName: "aml_feature")
+        self.mapView.attributionButton.isHidden = true
     }
 
     public func makeUIView(context: UIViewRepresentableContext<_MGLMapViewWrapper>) -> MGLMapView {

--- a/Tests/AmplifyMapLibreUITests/AMLMapCompositeViewTestCase.swift
+++ b/Tests/AmplifyMapLibreUITests/AMLMapCompositeViewTestCase.swift
@@ -12,12 +12,12 @@ import Mapbox
 @testable import AmplifyMapLibreUI
 
 class AMLMapCompositeViewTestCase: XCTestCase {
-    
+
     private func compositeView(with mapState: AMLMapViewState) -> AMLMapCompositeView {
         let viewModel = AMLMapCompositeViewModel(mapState: mapState)
         return AMLMapCompositeView(viewModel: viewModel)
     }
-    
+
     func testShowUserLocation() {
         // User supplied map
         do {
@@ -25,7 +25,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .showUserLocation(true)
-            
+
             XCTAssertTrue(map.viewModel.mapSettings.showUserLocation)
         }
         // Framework generated map
@@ -35,7 +35,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
             XCTAssertTrue(map.viewModel.mapSettings.showUserLocation)
         }
     }
-    
+
     func testAllowedZoomLevels() {
         // User supplied map
         do {
@@ -43,7 +43,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .allowedZoomLevels(5 ... 15)
-            
+
             XCTAssertEqual(map.viewModel.mapSettings.minZoomLevel, 5)
             XCTAssertEqual(map.viewModel.mapSettings.maxZoomLevel, 15)
         }
@@ -51,12 +51,12 @@ class AMLMapCompositeViewTestCase: XCTestCase {
         do {
             let map = AMLMapCompositeView()
                 .allowedZoomLevels(5 ... 15)
-            
+
             XCTAssertEqual(map.viewModel.mapSettings.minZoomLevel, 5)
             XCTAssertEqual(map.viewModel.mapSettings.maxZoomLevel, 15)
         }
     }
-       
+
     func testMaxZoomLevel() {
         // User supplied map
         do {

--- a/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
+++ b/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
@@ -47,28 +47,28 @@ final class AMLMapViewTestCase: XCTestCase {
 
         // Test range with allowed lower and upper bounds
         do {
-            let mapView = mapView.allowedZoomLevels(1.5...19)
+            let mapView = mapView.allowedZoomLevels(1.5 ... 19)
             XCTAssertEqual(mapView.mapSettings.minZoomLevel, 1.5)
             XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 19)
         }
 
         // Test range with allowed lower bound and unallowed upper bound
         do {
-            let mapView = mapView.allowedZoomLevels(2...40)
+            let mapView = mapView.allowedZoomLevels(2 ... 40)
             XCTAssertEqual(mapView.mapSettings.minZoomLevel, 2)
             XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 22)
         }
 
         // Test range with unallowed lower bound and allowed upper bound
         do {
-            let mapView = mapView.allowedZoomLevels(-4...20)
+            let mapView = mapView.allowedZoomLevels(-4 ... 20)
             XCTAssertEqual(mapView.mapSettings.minZoomLevel, 0)
             XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 20)
         }
 
         // Test range with unallowed lower and upper bounds
         do {
-            let mapView = mapView.allowedZoomLevels(-4...23)
+            let mapView = mapView.allowedZoomLevels(-4 ... 23)
             XCTAssertEqual(mapView.mapSettings.minZoomLevel, 0)
             XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 22)
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Added an internal `AMLMapAttributionView` to display attribution text. This was done on the `AMLMapView` in SwiftUI instead of the `_MGLMapViewWrapper` because of an apparent issue with pulling proper attribution in MapLibre's MGLMapView.

The attribution view handles short and long attribution strings by contracting / expanding the view. It also displays an appropriate size depending on the device type / layout.

*Check points: (check or cross out if not relevant)*

- [x] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [x] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all targets using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
