### PR TITLE
fix(UI): Remove ability to hide attribution button

### DIFF
--- a/HostApp/HostApp/Views/AMLMapView_View.swift
+++ b/HostApp/HostApp/Views/AMLMapView_View.swift
@@ -30,7 +30,6 @@ struct AMLMapView_View: View {
                 AMLMapView(mapState: viewModel.mapState)
                     .showUserLocation(true)
                     .allowedZoomLevels(5 ... 15)
-                    .hideAttributionButton(true)
                     .compassPosition(.bottomRight)
                     .featureImage {
                         return UIImage(

--- a/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositiveView+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositiveView+ViewModifiers.swift
@@ -82,14 +82,6 @@ public extension AMLMapCompositeView {
         return self
     }
 
-    /// Set map's attribution button to hidden or showing.
-    /// - Parameter hide:`true` hides the button / `false` unhides the button
-    /// - Returns: An instance of `AMLMapCompositeView`.
-    func hideAttributionButton(_ hide: Bool) -> AMLMapCompositeView {
-        viewModel.mapSettings.hideAttributionButton = hide
-        return self
-    }
-
     /// Provide an SwiftUI view that represents a point on a map.
     ///
     /// - Important: Because the underlying `MGLMapView` consumes `UIImage`s,

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ViewModifiers.swift
@@ -82,14 +82,6 @@ public extension AMLMapView {
         return self
     }
 
-    /// Set map's attribution button to hidden or showing.
-    /// - Parameter hide:`true` hides the button / `false` unhides the button
-    /// - Returns: An instance of `AMLMapView`.
-    func hideAttributionButton(_ hide: Bool) -> AMLMapView {
-        mapSettings.hideAttributionButton = hide
-        return self
-    }
-
     /// Provide an SwiftUI view that represents a point on a map.
     ///
     /// - Important: Because the underlying `MGLMapView` consumes `UIImage`s,

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
@@ -69,14 +69,12 @@ public struct AMLMapView: View {
                     .minZoomLevel(mapSettings.minZoomLevel)
                     .maxZoomLevel(mapSettings.maxZoomLevel)
 
-                if !mapSettings.hideAttributionButton {
-                    VStack {
-                        Spacer()
-                        AMLMapAttributionView(
-                            isAttributionTextDisplayed: $mapState.isAttributionTextDisplayed,
-                            attributionText: mapState.attribution
-                        )
-                    }
+                VStack {
+                    Spacer()
+                    AMLMapAttributionView(
+                        isAttributionTextDisplayed: $mapState.isAttributionTextDisplayed,
+                        attributionText: mapState.attribution
+                    )
                 }
             }
         case .error(let error):

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
@@ -22,9 +22,6 @@ internal class AMLMapViewSettings: ObservableObject {
     /// The map's maximum allowed zoom level.
     @Published internal var maxZoomLevel: Double
 
-    /// Whether the attribution button is hidden.
-    @Published internal var hideAttributionButton: Bool
-
     /// The compass position on the map.
     @Published internal var compassPosition: MGLOrnamentPosition
 
@@ -45,7 +42,6 @@ internal class AMLMapViewSettings: ObservableObject {
     ///   and the user must choose to allow access.
     ///   - minZoomLevel: The map's minimum allowed zoom level. Default is `0`
     ///   - maxZoomLevel: The map's maximum allowed zoom level. Default is `22`
-    ///   - hideAttributionButton: Whether the attribution button is hidden. Default is `false`
     ///   - compassPosition: The position of the compass on the map. Default is `.bottomleft`
     ///   - featureImage: The image representing a feature on the map. Default is `AMLFeatureView`.
     ///   - clusteringBehavior: Define the map views clustering behavior.
@@ -56,7 +52,6 @@ internal class AMLMapViewSettings: ObservableObject {
         showUserLocation: Bool = false,
         minZoomLevel: Double = 0,
         maxZoomLevel: Double = 22,
-        hideAttributionButton: Bool = false,
         compassPosition: MGLOrnamentPosition = .bottomLeft,
         featureImage: UIImage = UIImage(
             named: "AMLFeatureView",
@@ -69,7 +64,6 @@ internal class AMLMapViewSettings: ObservableObject {
         self.showUserLocation = showUserLocation
         self.minZoomLevel = minZoomLevel
         self.maxZoomLevel = maxZoomLevel
-        self.hideAttributionButton = hideAttributionButton
         self.compassPosition = compassPosition
         self.featureImage = featureImage
         self.clusteringBehavior = clusteringBehavior


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
We should not expose a public API to hide the attribution button of the `AMLMapView` or `AMLMapCompositeView`.
This PR removes the existing view modifiers on these Views and removes the `hideAttributionButton` property from `AMLMapViewSettings`.

*Check points: (check or cross out if not relevant)*

- [x] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [x] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all targets using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Documentation update for the change if required
> Amplify docs don't need to be updated. API docs will be regenerated after merge and before a new release is cut.
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions
> This is a breaking change as it removes public methods. This will be detailed in the release changelog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
