### PR TITLE
fix: Build failure due to external dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "35ed09d6e204dc59d0c1415bba3c29986c82e63a",
-          "version": "2.2.0"
+          "revision": "5268948fdd0323bb5ef2a487c36d4b64b2a31c83",
+          "version": "2.12.0"
+        }
+      },
+      {
+        "package": "AmplifyUtilsNotifications",
+        "repositoryURL": "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+        "state": {
+          "branch": null,
+          "revision": "f970384ad1035732f99259255cd2f97564807e41",
+          "version": "1.1.0"
         }
       },
       {
@@ -15,26 +24,26 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "da88cf1cab82e281e7277cd9feb9efc87a057041",
-          "version": "2.1.1"
+          "revision": "b036e83716789c13a3480eeb292b70caa54114f2",
+          "version": "3.1.0"
         }
       },
       {
-        "package": "AwsCrt",
-        "repositoryURL": "https://github.com/awslabs/aws-crt-swift.git",
+        "package": "aws-crt-swift",
+        "repositoryURL": "https://github.com/awslabs/aws-crt-swift",
         "state": {
           "branch": null,
-          "revision": "1846c60b9d50034f684384d8eef5e5aef7c40d6b",
-          "version": "0.3.1"
+          "revision": "6feec6c3787877807aa9a00fad09591b96752376",
+          "version": "0.6.1"
         }
       },
       {
-        "package": "AWSSwiftSDK",
+        "package": "aws-sdk-swift",
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "3a2b88928888b90feeec203137642fee7f1329e2",
-          "version": "0.5.0"
+          "revision": "24bae88a2391fe75da8a940a544d1ef6441f5321",
+          "version": "0.13.0"
         }
       },
       {
@@ -47,12 +56,12 @@
         }
       },
       {
-        "package": "ClientRuntime",
-        "repositoryURL": "https://github.com/awslabs/smithy-swift.git",
+        "package": "smithy-swift",
+        "repositoryURL": "https://github.com/awslabs/smithy-swift",
         "state": {
           "branch": null,
-          "revision": "e4285fe2b80bcc4eabe67f82b1c84344ec86124d",
-          "version": "0.5.0"
+          "revision": "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+          "version": "0.15.0"
         }
       },
       {
@@ -78,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-          "version": "1.0.3"
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       },
       {
@@ -87,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
-          "version": "1.4.4"
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
         }
       },
       {
@@ -96,8 +105,8 @@
         "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder.git",
         "state": {
           "branch": null,
-          "revision": "c438dad94f6a243b411b70a4b4bac54595064808",
-          "version": "0.15.0"
+          "revision": "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+          "version": "0.17.1"
         }
       }
     ]

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
@@ -98,12 +98,14 @@ class AWSMapURLProtocol: URLProtocol {
             var signedRequest = request
             signedRequest.url = originalURLComponents.url
             signedRequest.addValue(host, forHTTPHeaderField: "host")
-            guard let url = await AWSSigV4Signer.sigV4SignedURL(requestBuilder: requestBuilder,
-                                          credentialsProvider: geoConfig.credentialsProvider,
-                                          signingName: "geo",
-                                          signingRegion: geoConfig.regionName,
-                                          date: Date(),
-                                                                expiration: 60) else {
+            guard let url = await AWSSigV4Signer.sigV4SignedURL(
+                requestBuilder: requestBuilder,
+                credentialsProvider: geoConfig.credentialsProvider,
+                signingName: "geo",
+                signingRegion: geoConfig.regionName,
+                date: Date(),
+                expiration: 60,
+                signingAlgorithm: .sigv4) else {
                 completionHandler(.failure(AWSMapURLProtocolError.signatureError))
                 return
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A change in dependent package has caused build failure in amplify-ios-maplibre. Looks like AWS SDK for Swift released a breaking change - https://github.com/awslabs/aws-sdk-swift/pull/818 that added a required parameter. This PR fixes the build issue.

*Check points: (check or cross out if not relevant)*

- [x] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [x] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all targets using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
