### PR TITLE
feat: Upgrading to latest version of MapLibre iOS

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,9 +10,9 @@ jobs:
   xcodebuild_and_test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           persist-credentials: false
 
       - name: Build and test
-        run: xcodebuild test -scheme "AmplifyMapLibreAdapter-Package" -destination "platform=iOS Simulator,name=iPhone 11 Pro" | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        run: xcodebuild test -scheme "AmplifyMapLibreAdapter-Package" -destination "platform=iOS Simulator,name=iPhone 15 Pro" | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}

--- a/HostApp/HostApp/CompositeParentView.swift
+++ b/HostApp/HostApp/CompositeParentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import CoreLocation
 import AmplifyMapLibreAdapter
 import AmplifyMapLibreUI
-import Mapbox
+import MapLibre
 import Amplify
 
 // swiftlint:disable:next type_name

--- a/HostApp/HostApp/Views/AMLMapCompositeView_View.swift
+++ b/HostApp/HostApp/Views/AMLMapCompositeView_View.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import CoreLocation
 import AmplifyMapLibreAdapter
 import AmplifyMapLibreUI
-import Mapbox
+import MapLibre
 import Amplify
 
 // swiftlint:disable:next type_name

--- a/HostApp/HostApp/Views/AMLMapView_View.swift
+++ b/HostApp/HostApp/Views/AMLMapView_View.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AmplifyMapLibreAdapter
 import AmplifyMapLibreUI
 import CoreLocation
-import Mapbox
+import MapLibre
 import Amplify
 import Combine
 
@@ -97,8 +97,8 @@ struct AMLMapView_View_Previews: PreviewProvider {
 }
 
 extension AMLMapView_View {
-    private func didSelectFeature(_ mapView: MGLMapView, _ pointFeature: MGLPointFeature) {
-        let camera = MGLMapCamera(
+    private func didSelectFeature(_ mapView: MLNMapView, _ pointFeature: MLNPointFeature) {
+        let camera = MLNMapCamera(
             lookingAtCenter: pointFeature.coordinate,
             altitude: mapView.camera.altitude,
             pitch: mapView.camera.pitch,

--- a/HostApp/HostApp/Views/AMLMapView_ViewModel.swift
+++ b/HostApp/HostApp/Views/AMLMapView_ViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 import Amplify
 import AmplifyMapLibreAdapter
 import AmplifyMapLibreUI

--- a/HostApp/HostApp/Views/SimpleAMLMapView_View.swift
+++ b/HostApp/HostApp/Views/SimpleAMLMapView_View.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AmplifyMapLibreAdapter
 import AmplifyMapLibreUI
 import CoreLocation
-import Mapbox
+import MapLibre
 import Amplify
 import Combine
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "f4d2466b137858e63d1696e31179a8944ef8a789",
-          "version": "2.33.4"
+          "revision": "99c72db23217c8944dda92a9be26f7c0d0d5de3f",
+          "version": "2.37.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "e78ae0220e17525a15ac68c697a155eb7a672a8e",
-          "version": "0.15.0"
+          "revision": "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
+          "version": "0.15.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-          "version": "1.5.4"
+          "revision": "9cb486020ebf03bfa5b5df985387a14a98744537",
+          "version": "1.6.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "5268948fdd0323bb5ef2a487c36d4b64b2a31c83",
-          "version": "2.12.0"
+          "revision": "0b1a2da28c0d3b7a64ac6d72eb4a85eb1885ea17",
+          "version": "2.25.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
         "state": {
           "branch": null,
-          "revision": "f970384ad1035732f99259255cd2f97564807e41",
-          "version": "1.1.0"
+          "revision": "959eec669ba97c7d923b963c3e66ca8a0b2737f6",
+          "version": "1.1.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "b036e83716789c13a3480eeb292b70caa54114f2",
-          "version": "3.1.0"
+          "revision": "a08684c5004e2049c29f57a5938beae9695a1ef7",
+          "version": "3.1.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/awslabs/aws-crt-swift",
         "state": {
           "branch": null,
-          "revision": "6feec6c3787877807aa9a00fad09591b96752376",
-          "version": "0.6.1"
+          "revision": "fd1756b6e5c9fd1a906edfb743f7cb64c2c98639",
+          "version": "0.17.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "24bae88a2391fe75da8a940a544d1ef6441f5321",
-          "version": "0.13.0"
+          "revision": "387016f3e62119e9962da4357c63671c694554e6",
+          "version": "0.31.0"
         }
       },
       {
@@ -57,11 +57,11 @@
       },
       {
         "package": "smithy-swift",
-        "repositoryURL": "https://github.com/awslabs/smithy-swift",
+        "repositoryURL": "https://github.com/smithy-lang/smithy-swift",
         "state": {
           "branch": null,
-          "revision": "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-          "version": "0.15.0"
+          "revision": "ab999a9f0c972adcb350beda3c630a35697f7e8e",
+          "version": "0.35.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
+          "revision": "d029d9d39c87bed85b1c50adee7c41795261a192",
+          "version": "1.0.6"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
-          "version": "1.5.2"
+          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+          "version": "1.5.3"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder.git",
         "state": {
           "branch": null,
-          "revision": "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-          "version": "0.17.1"
+          "revision": "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+          "version": "0.17.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "0b1a2da28c0d3b7a64ac6d72eb4a85eb1885ea17",
-          "version": "2.25.2"
+          "revision": "f4d2466b137858e63d1696e31179a8944ef8a789",
+          "version": "2.33.4"
         }
       },
       {
@@ -20,21 +20,12 @@
         }
       },
       {
-        "package": "AppSyncRealTimeClient",
-        "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-        "state": {
-          "branch": null,
-          "revision": "a08684c5004e2049c29f57a5938beae9695a1ef7",
-          "version": "3.1.2"
-        }
-      },
-      {
         "package": "aws-crt-swift",
         "repositoryURL": "https://github.com/awslabs/aws-crt-swift",
         "state": {
           "branch": null,
-          "revision": "fd1756b6e5c9fd1a906edfb743f7cb64c2c98639",
-          "version": "0.17.0"
+          "revision": "0d0a0cf2e2cb780ceeceac190b4ede94f4f96902",
+          "version": "0.26.0"
         }
       },
       {
@@ -42,17 +33,17 @@
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "387016f3e62119e9962da4357c63671c694554e6",
-          "version": "0.31.0"
+          "revision": "47922c05dd66be717c7bce424651a534456717b7",
+          "version": "0.36.2"
         }
       },
       {
-        "package": "MapLibre GL Native",
+        "package": "MapLibre Native",
         "repositoryURL": "https://github.com/maplibre/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
-          "revision": "d524c18d8c572db72c753f88492c36b9749725e1",
-          "version": "5.12.0"
+          "revision": "6579f48fe126ce2916f7b5d0c84c1869d790c4e4",
+          "version": "6.4.1"
         }
       },
       {
@@ -60,8 +51,8 @@
         "repositoryURL": "https://github.com/smithy-lang/smithy-swift",
         "state": {
           "branch": null,
-          "revision": "ab999a9f0c972adcb350beda3c630a35697f7e8e",
-          "version": "0.35.0"
+          "revision": "8a5b0105c1b8a1d26a9435fb0af3959a7f5de578",
+          "version": "0.41.1"
         }
       },
       {
@@ -69,26 +60,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "5f5ad81ac0d0a0f3e56e39e646e8423c617df523",
-          "version": "0.13.2"
-        }
-      },
-      {
-        "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream",
-        "state": {
-          "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections",
-        "state": {
-          "branch": null,
-          "revision": "d029d9d39c87bed85b1c50adee7c41795261a192",
-          "version": "1.0.6"
+          "revision": "e78ae0220e17525a15ac68c697a155eb7a672a8e",
+          "version": "0.15.0"
         }
       },
       {
@@ -96,17 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-          "version": "1.5.3"
-        }
-      },
-      {
-        "package": "XMLCoder",
-        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder.git",
-        "state": {
-          "branch": null,
-          "revision": "80b4a1646399b8e4e0ce80711653476a85bd5e37",
-          "version": "0.17.0"
+          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+          "version": "1.5.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,9 @@ let package = Package(
 
         // MapLibre
         .package(
-            name: "MapLibre GL Native",
+            name: "MapLibre Native",
             url: "https://github.com/maplibre/maplibre-gl-native-distribution",
-            .exact("5.12.0")
+            .exact("6.4.1")
         )
     ],
     targets: [
@@ -40,7 +40,7 @@ let package = Package(
                 .product(name: "Amplify", package: "Amplify"),
                 .product(name: "AWSCognitoAuthPlugin", package: "Amplify"),
                 .product(name: "AWSLocationGeoPlugin", package: "Amplify"),
-                .product(name: "Mapbox", package: "MapLibre GL Native")
+                .product(name: "MapLibre", package: "MapLibre Native")
             ]
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The AmplifyMapLibreAdapter is a library that combines the Amplify Geo category a
 
 - Brokers communication between Amplify and MapLibre by providing functions and extensions that simplify using Amplify Geo with MapLibre.
 
-- Provide SwiftUI support for MapLibre that adds `AMLMapView` (Amplify MapLibre MapView) and `AMLMapCompositeView` Views around MapLibre's MGLMapView. This introduces SwiftUI support to the MapLibre SDK for iOS. It provides a subset of MGLMapView functionality that can be used for displaying and interacting with a map; providing APIs to track state changes, inject custom implementations for user interaction, and define settings.
+- Provide SwiftUI support for MapLibre that adds `AMLMapView` (Amplify MapLibre MapView) and `AMLMapCompositeView` Views around MapLibre's MLNMapView. This introduces SwiftUI support to the MapLibre SDK for iOS. It provides a subset of MLNMapView functionality that can be used for displaying and interacting with a map; providing APIs to track state changes, inject custom implementations for user interaction, and define settings.
 
 ## Usage
 
@@ -33,7 +33,7 @@ Swift Pacakge Manager is distributed with Xcode. To add AmplifyMapLibreAdapter t
 6. Enter the AmplifyMapLibreAdapter GitHub repo URL (`https://github.com/aws-amplify/amplify-ios-maplibre`) in the search bar labeled **Search or Enter Package URL**.
 7. Click **Add Package** and select your desired **Dependency Rule**
 8. Select the targets you would like to add.
-    - **AmplifyMapLibreAdapter** will allow you to create a `MGLMapView` configured to work with Amplify Geo.
+    - **AmplifyMapLibreAdapter** will allow you to create a `MLNMapView` configured to work with Amplify Geo.
     - **AmplifyMapLibreUI** provides SwiftUI Map Views, `AMLMapView` and `AMLMapCompositeView`. Additionally, it also provides other map related UI components with applicable functionality, such as a `AMLSearchBar`, `AMLPlaceList`, `AMLMapControlView`, and more. All of which seamlessly integrate with Amplify Geo.
 
 ## Reporting Bugs/Feature Requests

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
@@ -9,6 +9,7 @@ import Foundation
 import Amplify
 import AWSLocationGeoPlugin
 import AWSClientRuntime
+import InternalAmplifyCredentials
 
 extension AWSMapURLProtocol {
     struct GeoConfig {
@@ -21,7 +22,10 @@ extension AWSMapURLProtocol {
                 assertionFailure(AWSMapURLProtocolError.configurationError.localizedDescription)
                 return nil
             }
-            self.credentialsProvider = plugin.authService.getCredentialsProvider()
+            guard let credentiaslProvider = plugin.authService as? AWSAuthCredentialsProviderBehavior else {
+                return nil
+            }
+            self.credentialsProvider = credentiaslProvider.getCredentialsProvider()
             self.regionName = plugin.pluginConfig.regionName
             self.hostName = "maps.geo.\(regionName).amazonaws.com"
         }

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
@@ -13,7 +13,7 @@ import AWSClientRuntime
 extension AWSMapURLProtocol {
     struct GeoConfig {
         let regionName: String
-        let credentialsProvider: CredentialsProvider
+        let credentialsProvider: CredentialsProviding
         let hostName: String
 
         init?() {

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
@@ -88,7 +88,7 @@ class AWSMapURLProtocol: URLProtocol {
 
         let requestBuilder = SdkHttpRequestBuilder()
             .withHost(host)
-            .withPath(originalURLComponents.path)
+            .withPath(originalURLComponents.path.urlPercentEncoding(encodeForwardSlash: false))
             .withMethod(.get)
             .withPort(443)
             .withProtocol(.https)

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol.swift
@@ -93,7 +93,7 @@ class AWSMapURLProtocol: URLProtocol {
             .withPort(443)
             .withProtocol(.https)
             .withHeader(name: "host", value: host)
-        
+
         Task {
             var signedRequest = request
             signedRequest.url = originalURLComponents.url
@@ -105,7 +105,8 @@ class AWSMapURLProtocol: URLProtocol {
                 signingRegion: geoConfig.regionName,
                 date: Date(),
                 expiration: 60,
-                signingAlgorithm: .sigv4) else {
+                signingAlgorithm: .sigv4)
+            else {
                 completionHandler(.failure(AWSMapURLProtocolError.signatureError))
                 return
             }

--- a/Sources/AmplifyMapLibreAdapter/AmplifyMapLibre.swift
+++ b/Sources/AmplifyMapLibreAdapter/AmplifyMapLibre.swift
@@ -7,34 +7,34 @@
 
 import Foundation
 import CoreLocation
-import Mapbox
+import MapLibre
 import Amplify
 import AWSLocationGeoPlugin
 
 public class AmplifyMapLibre {
 
-    /// Creates an instance of MGLMapView configured to work with Amplify and Amazon
+    /// Creates an instance of MLNMapView configured to work with Amplify and Amazon
     /// Location Service using the default map
-    @MainActor public class func createMap() async throws -> MGLMapView {
-        AWSMapURLProtocol.register(sessionConfig: MGLNetworkConfiguration.sharedManager.sessionConfiguration)
+    @MainActor public class func createMap() async throws -> MLNMapView {
+        AWSMapURLProtocol.register(sessionConfig: MLNNetworkConfiguration.sharedManager.sessionConfiguration)
         let map = try await Amplify.Geo.defaultMap()
-        return MGLMapView(frame: .zero, styleURL: map.styleURL)
+        return MLNMapView(frame: .zero, styleURL: map.styleURL)
     }
 
-    /// Creates an instance of MGLMapView configured to work with Amplify and Amazon
+    /// Creates an instance of MLNMapView configured to work with Amplify and Amazon
     /// Location Service using the specified MapStyle.
     /// - Parameter mapStyle: The MapStyle for the map. (optional, default: The MapStyle
     /// that corresponds to the default map in amplifyconfiguration.json)
-    /// - Returns: An instance of MGLMapView.
-    public class func createMap(_ mapStyle: Geo.MapStyle) -> MGLMapView {
-        AWSMapURLProtocol.register(sessionConfig: MGLNetworkConfiguration.sharedManager.sessionConfiguration)
-        return MGLMapView(frame: .zero, styleURL: mapStyle.styleURL)
+    /// - Returns: An instance of MLNMapView.
+    public class func createMap(_ mapStyle: Geo.MapStyle) -> MLNMapView {
+        AWSMapURLProtocol.register(sessionConfig: MLNNetworkConfiguration.sharedManager.sessionConfiguration)
+        return MLNMapView(frame: .zero, styleURL: mapStyle.styleURL)
     }
 
-    /// Convert a Place array to an MGLPointFeature array that is ready to be displayed on a map.
+    /// Convert a Place array to an MLNPointFeature array that is ready to be displayed on a map.
     /// - Parameter places: Place array to convert.
-    /// - Returns: MGLPointFeature array.
-    public class func createFeatures(_ places: [Geo.Place]) -> [MGLPointFeature] {
-        places.map(MGLPointFeature.init)
+    /// - Returns: MLNPointFeature array.
+    public class func createFeatures(_ places: [Geo.Place]) -> [MLNPointFeature] {
+        places.map(MLNPointFeature.init)
     }
 }

--- a/Sources/AmplifyMapLibreAdapter/Extensions/Geo.BoundingBox+MLNCoordinateBounds.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/Geo.BoundingBox+MLNCoordinateBounds.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 import Amplify
-import Mapbox
+import MapLibre
 
 public extension Geo.BoundingBox {
-    /// Initialize a BoundingBox from a MGLCoordinateBounds
+    /// Initialize a BoundingBox from a MLNCoordinateBounds
     /// - Parameter bounds: The CLLocationCoordinate2D to use to initialize the
     /// Location.
-    init(_ bounds: MGLCoordinateBounds) {
+    init(_ bounds: MLNCoordinateBounds) {
         let southwest = Geo.Coordinates(bounds.sw)
         let northeast = Geo.Coordinates(bounds.ne)
 

--- a/Sources/AmplifyMapLibreAdapter/Extensions/Geo.SearchArea+MLNCoorindateBounds.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/Geo.SearchArea+MLNCoorindateBounds.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 import Amplify
-import Mapbox
+import MapLibre
 
 public extension Geo.SearchArea {
     /// Creates a SearchArea that only returns places within the provided
-    /// MGLCoordinateBounds.
+    /// MLNCoordinateBounds.
     /// - Parameter bounds: The bounds for the search area.
     /// - Returns: The SearchArea.
-    static func within(_ bounds: MGLCoordinateBounds) -> Geo.SearchArea {
+    static func within(_ bounds: MLNCoordinateBounds) -> Geo.SearchArea {
         .within(Geo.BoundingBox(bounds))
     }
 }

--- a/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Geo.Place.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Geo.Place.swift
@@ -6,12 +6,12 @@
 //
 
 import Foundation
-import Mapbox
+import MapLibre
 import Amplify
 
-public extension MGLPointFeature {
-    /// Initialize an MGLPointFeature with the title and coordinates of a given Geo.Place
-    /// - Parameter place: The Geo.Place from which to initialize the MGLPointFeature.
+public extension MLNPointFeature {
+    /// Initialize an MLNPointFeature with the title and coordinates of a given Geo.Place
+    /// - Parameter place: The Geo.Place from which to initialize the MLNPointFeature.
     convenience init(_ place: Geo.Place) {
         self.init()
         title = place.label
@@ -24,8 +24,8 @@ public extension MGLPointFeature {
     }
 }
 
-// MARK: MGLPointFeature+Geo.Place property
-public extension MGLPointFeature {
+// MARK: MLNPointFeature+Geo.Place property
+public extension MLNPointFeature {
     var amlGeoPlace: Geo.Place? {
         get {
             guard let coordinates = attributes[\.coordinates],

--- a/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Geo.Place.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Geo.Place.swift
@@ -84,7 +84,8 @@ public extension Geo.Place {
         if let placeLabel = label,
            let street = street,
            let streetIndex = label?.range(of: street)?.lowerBound,
-           let commaIndex = placeLabel[..<streetIndex].range(of: ",", options: .backwards)?.lowerBound {
+           let commaIndex = placeLabel[..<streetIndex].range(of: ",", options: .backwards)?.lowerBound
+        {
             return String(placeLabel[..<commaIndex])
         } else {
             return label
@@ -93,7 +94,7 @@ public extension Geo.Place {
 }
 
 // MARK: Fileprivate subscript helpers
-fileprivate extension Dictionary where Key == String, Value == Any {
+private extension Dictionary where Key == String, Value == Any {
     private func placeKey<T>(for keyPath: KeyPath<Geo.Place, T>) -> String {
         switch keyPath {
         case \Geo.Place.street: return "aml_geo.place_street"

--- a/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Init.swift
+++ b/Sources/AmplifyMapLibreAdapter/Extensions/MLNPointFeature+Init.swift
@@ -6,10 +6,10 @@
 //
 
 import Foundation
-import Mapbox
+import MapLibre
 
-public extension MGLPointFeature {
-    /// Initialize an MGLPointFeature with a given title and coordinates
+public extension MLNPointFeature {
+    /// Initialize an MLNPointFeature with a given title and coordinates
     /// - Parameters:
     ///   - title: The feature title.
     ///   - coordinates: The feature coordinates.

--- a/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositeView.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositeView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import CoreLocation
-import Mapbox
+import MapLibre
 import Amplify
 import AmplifyMapLibreAdapter
 

--- a/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositeViewModel.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositeViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 import Amplify
 import AmplifyMapLibreAdapter
 

--- a/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositiveView+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapCompositeView/AMLMapCompositiveView+ViewModifiers.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import CoreLocation
-import Mapbox
+import MapLibre
 import SwiftUI
 
 public extension AMLMapCompositeView {
@@ -84,7 +84,7 @@ public extension AMLMapCompositeView {
 
     /// Provide an SwiftUI view that represents a point on a map.
     ///
-    /// - Important: Because the underlying `MGLMapView` consumes `UIImage`s,
+    /// - Important: Because the underlying `MLNMapView` consumes `UIImage`s,
     ///   this method turns a `SwiftUI` view into a `UIImage`.
     ///   There may be hidden cost to using this. If you experience performance and / or
     ///   rendering issues, please use the `featureImage(_:)` view modifier instead.
@@ -108,13 +108,13 @@ public extension AMLMapCompositeView {
     /// The default implementation pans the feature to the center of the screen and presents an `AMLCalloutView`.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeature`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeature`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeature` as needed.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func featureTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeature: MGLPointFeature
+            _ mapView: MLNMapView,
+            _ pointFeature: MLNPointFeature
         ) -> Void
     ) -> AMLMapCompositeView {
         viewModel.mapSettings.proxyDelegate.featureTapped = implementation
@@ -126,30 +126,30 @@ public extension AMLMapCompositeView {
     /// The default implementation zooms in on the map.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeatureCluster`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeatureCluster`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeatureCluster` as needed.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func featureClusterTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeatureCluster: MGLPointFeatureCluster
+            _ mapView: MLNMapView,
+            _ pointFeatureCluster: MLNPointFeatureCluster
         ) -> Void
     ) -> AMLMapCompositeView {
         viewModel.mapSettings.proxyDelegate.clusterTapped = implementation
         return self
     }
 
-    /// Set the position of the compass on the `MGLMapView`.
-    /// - Parameter position: `MGLOrnamentPosition` defining the location.
+    /// Set the position of the compass on the `MLNMapView`.
+    /// - Parameter position: `MLNOrnamentPosition` defining the location.
     /// - Returns: An instance of `AMLMapCompositeView`.
-    func compassPosition(_ position: MGLOrnamentPosition) -> AMLMapCompositeView {
+    func compassPosition(_ position: MLNOrnamentPosition) -> AMLMapCompositeView {
         viewModel.mapSettings.compassPosition = position
         return self
     }
 
     /// Set whether the map features should cluster.
     /// - Parameter shouldCluster: Features displayed on the map should cluster.
-    /// Corresponds to the `MGLShapeSourceOption` `.clustered`.
+    /// Corresponds to the `MLNShapeSourceOption` `.clustered`.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func shouldCluster(_ shouldCluster: Bool) -> AMLMapCompositeView {
         viewModel.mapSettings.clusteringBehavior.shouldCluster = shouldCluster
@@ -158,7 +158,7 @@ public extension AMLMapCompositeView {
 
     /// Specifies the maximum zoom level at which to cluster points if clustering is enabled.
     /// - Parameter maxZoom: The maximum zoom level of clustering.
-    ///   Corresponds to `MGLShapeSourceOption` `.maximumZoomLevelForClustering`.
+    ///   Corresponds to `MLNShapeSourceOption` `.maximumZoomLevelForClustering`.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func maximumClusterZoomLevel(_ maxZoom: Int) -> AMLMapCompositeView {
         viewModel.mapSettings.clusteringBehavior.maximumZoomLevel = maxZoom
@@ -167,7 +167,7 @@ public extension AMLMapCompositeView {
 
     /// Set the fill color of the circle cluster.
     /// - Parameter color: The fill color of the circle cluster.
-    ///   Sets the `MGLCircleStyleLayer` `circleColor` property.
+    ///   Sets the `MLNCircleStyleLayer` `circleColor` property.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func clusterColor(_ color: UIColor) -> AMLMapCompositeView {
         viewModel.mapSettings.clusteringBehavior.clusterColor = color
@@ -176,7 +176,7 @@ public extension AMLMapCompositeView {
 
     /// The text color of the number displayed in the circle cluster.
     /// - Parameter color: The color of text displaying the number within a cluster.
-    ///   Sets the `MGLSymbolStyleLayer` `textColor` property.
+    ///   Sets the `MLNSymbolStyleLayer` `textColor` property.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func clusterNumberColor(_ color: UIColor) -> AMLMapCompositeView {
         viewModel.mapSettings.clusteringBehavior.clusterNumberColor = color
@@ -195,7 +195,7 @@ public extension AMLMapCompositeView {
 
     /// Set the radius of each cluster if clustering is enabled.
     /// - Parameter radius: The cluster radius.
-    ///   Corresponds to the `MGLShapeSourceOption` `.clusterRadius`.
+    ///   Corresponds to the `MLNShapeSourceOption` `.clusterRadius`.
     /// - Returns: An instance of `AMLMapCompositeView`.
     func clusterRadius(_ radius: Int) -> AMLMapCompositeView {
         viewModel.mapSettings.clusteringBehavior.clusterRadius = radius

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ClusteringBehavior.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ClusteringBehavior.swift
@@ -18,20 +18,20 @@ extension AMLMapView {
         /// Define custom clustering behavior.
         /// - Parameters:
         ///   - shouldCluster: Whether the features displayed on the map should cluster. Default is `true`.
-        ///   Corresponds to the `MGLShapeSourceOption` `.clustered`.
+        ///   Corresponds to the `MLNShapeSourceOption` `.clustered`.
         ///
         ///   - maximumZoomLevel: Specifies the maximum zoom level at which to cluster points if clustering is enabled.
-        ///   Corresponds to `MGLShapeSourceOption` `.maximumZoomLevelForClustering`.
+        ///   Corresponds to `MLNShapeSourceOption` `.maximumZoomLevelForClustering`.
         ///
         ///   - clusterColor: The fill color of the circle cluster.
-        ///   Sets the `MGLCircleStyleLayer` `circleColor` property.
+        ///   Sets the `MLNCircleStyleLayer` `circleColor` property.
         ///
         ///   - clusterColorSteps: Dictionary representation of cluster color steps where the
         ///   `key` is the number of features in a cluster and the
         ///   `value` is the color for that corresponding number.
         ///
         ///   - clusterRadius: Specifies the radius of each cluster if clustering is enabled.
-        ///   Corresponds to the `MGLShapeSourceOption` `.clusterRadius`.
+        ///   Corresponds to the `MLNShapeSourceOption` `.clusterRadius`.
         init(
             shouldCluster: Bool = true,
             maximumZoomLevel: Int = 13,
@@ -51,19 +51,19 @@ extension AMLMapView {
         }
 
         /// Whether the features displayed on the map should cluster. Default is `true`.
-        /// Corresponds to the `MGLShapeSourceOption` `.clustered`.
+        /// Corresponds to the `MLNShapeSourceOption` `.clustered`.
         var shouldCluster: Bool
 
         /// Specifies the maximum zoom level at which to cluster points if clustering is enabled.
-        /// Corresponds to `MGLShapeSourceOption` `.maximumZoomLevelForClustering`.
+        /// Corresponds to `MLNShapeSourceOption` `.maximumZoomLevelForClustering`.
         var maximumZoomLevel: Int
 
         /// The fill color of the circle cluster.
-        /// Sets the `MGLCircleStyleLayer` `circleColor` property.
+        /// Sets the `MLNCircleStyleLayer` `circleColor` property.
         var clusterColor: UIColor
 
         /// The text color of the number displayed in the circle cluster.
-        /// Sets the `MGLSymbolStyleLayer` `textColor` property.
+        /// Sets the `MLNSymbolStyleLayer` `textColor` property.
         var clusterNumberColor: UIColor
 
         /// Dictionary representation of cluster color steps where the
@@ -72,7 +72,7 @@ extension AMLMapView {
         var clusterColorSteps: [Int: UIColor]
 
         /// Specifies the radius of each cluster if clustering is enabled.
-        /// Corresponds to the `MGLShapeSourceOption` `.clusterRadius`.
+        /// Corresponds to the `MLNShapeSourceOption` `.clusterRadius`.
         var clusterRadius: Int
     }
 }

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ProxyDelegate.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ProxyDelegate.swift
@@ -6,18 +6,18 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 import UIKit
 
 extension AMLMapView {
     /// An object that holds user defined or default behavior implementations
-    /// for actions taken with the underling `MGLMapView`.
+    /// for actions taken with the underling `MLNMapView`.
     class ProxyDelegate {
 
         init() { }
 
         /// The implementation that gets executed when a feature is tapped on the map.
-        var featureTapped: ((MGLMapView, MGLPointFeature) -> Void) = { mapView, pointFeature in
+        var featureTapped: ((MLNMapView, MLNPointFeature) -> Void) = { mapView, pointFeature in
 
             mapView.setCenter(
                 pointFeature.coordinate,
@@ -46,8 +46,8 @@ extension AMLMapView {
             /// If so, it removes it before add a new one.
             /// - Parameters:
             ///   - calloutView: The UIView to be presented as a callout view.
-            ///   - mapView: The MGLMapView on which the callout view will be presented.
-            func addCalloutView(_ calloutView: UIView, to mapView: MGLMapView) {
+            ///   - mapView: The MLNMapView on which the callout view will be presented.
+            func addCalloutView(_ calloutView: UIView, to mapView: MLNMapView) {
                 if let existingCalloutView = mapView.subviews.first(where: { $0.tag == 42 }) {
                     mapView.willRemoveSubview(existingCalloutView)
                     existingCalloutView.removeFromSuperview()
@@ -61,7 +61,7 @@ extension AMLMapView {
         }
 
         /// The implementation that gets executed when a feature cluster is tapped on the map.
-        var clusterTapped: ((MGLMapView, MGLPointFeatureCluster) -> Void) = { mapView, cluster in
+        var clusterTapped: ((MLNMapView, MLNPointFeatureCluster) -> Void) = { mapView, cluster in
             mapView.setCenter(
                 cluster.coordinate,
                 zoomLevel: min(15, mapView.zoomLevel + 2),

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView+ViewModifiers.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import CoreLocation
-import Mapbox
+import MapLibre
 import SwiftUI
 
 public extension AMLMapView {
@@ -84,7 +84,7 @@ public extension AMLMapView {
 
     /// Provide an SwiftUI view that represents a point on a map.
     ///
-    /// - Important: Because the underlying `MGLMapView` consumes `UIImage`s,
+    /// - Important: Because the underlying `MLNMapView` consumes `UIImage`s,
     ///   this method turns a `SwiftUI` view into a `UIImage`.
     ///   There may be hidden cost to using this. If you experience performance and / or
     ///   rendering issues, please use the `featureImage(_:)` view modifier instead.
@@ -108,13 +108,13 @@ public extension AMLMapView {
     /// The default implementation pans the feature to the center of the screen and presents an `AMLCalloutView`.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeature`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeature`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeature` as needed.
     /// - Returns: An instance of `AMLMapView`.
     func featureTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeature: MGLPointFeature
+            _ mapView: MLNMapView,
+            _ pointFeature: MLNPointFeature
         ) -> Void
     ) -> AMLMapView {
         mapSettings.proxyDelegate.featureTapped = implementation
@@ -126,30 +126,30 @@ public extension AMLMapView {
     /// The default implementation zooms in on the map.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeatureCluster`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeatureCluster`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeatureCluster` as needed.
     /// - Returns: An instance of `AMLMapView`.
     func featureClusterTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeatureCluster: MGLPointFeatureCluster
+            _ mapView: MLNMapView,
+            _ pointFeatureCluster: MLNPointFeatureCluster
         ) -> Void
     ) -> AMLMapView {
         mapSettings.proxyDelegate.clusterTapped = implementation
         return self
     }
 
-    /// Set the position of the compass on the `MGLMapView`.
-    /// - Parameter position: `MGLOrnamentPosition` defining the location.
+    /// Set the position of the compass on the `MLNMapView`.
+    /// - Parameter position: `MLNOrnamentPosition` defining the location.
     /// - Returns: An instance of `AMLMapView`.
-    func compassPosition(_ position: MGLOrnamentPosition) -> AMLMapView {
+    func compassPosition(_ position: MLNOrnamentPosition) -> AMLMapView {
         mapSettings.compassPosition = position
         return self
     }
 
     /// Set whether the map features should cluster.
     /// - Parameter shouldCluster: Features displayed on the map should cluster.
-    /// Corresponds to the `MGLShapeSourceOption` `.clustered`.
+    /// Corresponds to the `MLNShapeSourceOption` `.clustered`.
     /// - Returns: An instance of `AMLMapView`.
     func shouldCluster(_ shouldCluster: Bool) -> AMLMapView {
         mapSettings.clusteringBehavior.shouldCluster = shouldCluster
@@ -158,7 +158,7 @@ public extension AMLMapView {
 
     /// Specifies the maximum zoom level at which to cluster points if clustering is enabled.
     /// - Parameter maxZoom: The maximum zoom level of clustering.
-    ///   Corresponds to `MGLShapeSourceOption` `.maximumZoomLevelForClustering`.
+    ///   Corresponds to `MLNShapeSourceOption` `.maximumZoomLevelForClustering`.
     /// - Returns: An instance of `AMLMapView`.
     func maximumClusterZoomLevel(_ maxZoom: Int) -> AMLMapView {
         mapSettings.clusteringBehavior.maximumZoomLevel = maxZoom
@@ -167,7 +167,7 @@ public extension AMLMapView {
 
     /// Set the fill color of the circle cluster.
     /// - Parameter color: The fill color of the circle cluster.
-	///   Sets the `MGLCircleStyleLayer` `circleColor` property.
+	///   Sets the `MLNCircleStyleLayer` `circleColor` property.
     /// - Returns: An instance of `AMLMapView`.
     func clusterColor(_ color: UIColor) -> AMLMapView {
         mapSettings.clusteringBehavior.clusterColor = color
@@ -176,7 +176,7 @@ public extension AMLMapView {
 
     /// The text color of the number displayed in the circle cluster.
     /// - Parameter color: The color of text displaying the number within a cluster.
-    ///   Sets the `MGLSymbolStyleLayer` `textColor` property.
+    ///   Sets the `MLNSymbolStyleLayer` `textColor` property.
     /// - Returns: An instance of `AMLMapView`.
     func clusterNumberColor(_ color: UIColor) -> AMLMapView {
         mapSettings.clusteringBehavior.clusterNumberColor = color
@@ -194,7 +194,7 @@ public extension AMLMapView {
 
     /// Set the radius of each cluster if clustering is enabled.
     /// - Parameter radius: The cluster radius.
-    ///   Corresponds to the `MGLShapeSourceOption` `.clusterRadius`.
+    ///   Corresponds to the `MLNShapeSourceOption` `.clusterRadius`.
     /// - Returns: An instance of `AMLMapView`.
     func clusterRadius(_ radius: Int) -> AMLMapView {
         mapSettings.clusteringBehavior.clusterRadius = radius

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 import Amplify
 import AWSLocationGeoPlugin
-import Mapbox
+import MapLibre
 import AmplifyMapLibreAdapter
 
-/// The `SwiftUI` wrapper for `MGLMapView`
+/// The `SwiftUI` wrapper for `MLNMapView`
 public struct AMLMapView: View {
     /// Object to track state changes in the map.
     @ObservedObject var mapState: AMLMapViewState
@@ -50,7 +50,7 @@ public struct AMLMapView: View {
         switch mapLoadingState.state {
         case .complete(let mapView):
             ZStack {
-                _MGLMapViewWrapper(
+                _MLNMapViewWrapper(
                     mapView: mapView,
                     zoomLevel: $mapState.zoomLevel,
                     bounds: $mapState.bounds,

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewSettings.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 
 /// Configurable map settings. These values are set through view modifiers on `AMLMapView`.
 internal class AMLMapViewSettings: ObservableObject {
@@ -23,7 +23,7 @@ internal class AMLMapViewSettings: ObservableObject {
     @Published internal var maxZoomLevel: Double
 
     /// The compass position on the map.
-    @Published internal var compassPosition: MGLOrnamentPosition
+    @Published internal var compassPosition: MLNOrnamentPosition
 
     /// The image representing a feature on the map.
     @Published internal var featureImage: UIImage
@@ -52,7 +52,7 @@ internal class AMLMapViewSettings: ObservableObject {
         showUserLocation: Bool = false,
         minZoomLevel: Double = 0,
         maxZoomLevel: Double = 22,
-        compassPosition: MGLOrnamentPosition = .bottomLeft,
+        compassPosition: MLNOrnamentPosition = .bottomLeft,
         featureImage: UIImage = UIImage(
             named: "AMLFeatureView",
             in: Bundle.module,

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState+MapLoadingStateMachine.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState+MapLoadingStateMachine.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 import Amplify
 
 /// Simple internal state machine representing the different stages of loading a map asynchronously.
@@ -19,18 +19,18 @@ struct MapCreationStateMachine {
         /// Async fetching should begin.
         case begin
         /// Fetching has completed successfully.
-        case complete(MGLMapView)
+        case complete(MLNMapView)
         /// Fetching has completed unsuccessfully.
         case error(Geo.Error)
     }
 
-    /// Transition to a new state based on a `Result<MGLMapView, Geo.Error>`
+    /// Transition to a new state based on a `Result<MLNMapView, Geo.Error>`
     /// - Parameters:
     ///   - input: The async operation's result.
-    ///   - map: An optional `MGLMapView` that gets assigned if the `Result` was successful.
+    ///   - map: An optional `MLNMapView` that gets assigned if the `Result` was successful.
     mutating func transition(
-        input: Result<MGLMapView, Geo.Error>,
-        assign map: inout MGLMapView?
+        input: Result<MLNMapView, Geo.Error>,
+        assign map: inout MLNMapView?
     ) {
         switch input {
         case .success(let mapView):

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
@@ -36,7 +36,7 @@ public class AMLMapViewState: ObservableObject {
     @Published public var attribution: String?
 
     /// Whether the attribution test is currently being displayed.
-    @Published internal(set) public var isAttributionTextDisplayed: Bool
+    @Published public internal(set) var isAttributionTextDisplayed: Bool
 
     /// Create an `AMLMapViewState` object to track state changes.
     /// - Parameters:

--- a/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
+++ b/Sources/AmplifyMapLibreUI/AMLMapView/AMLMapViewState.swift
@@ -6,13 +6,13 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 import Amplify
 
 /// Object to track state changes.
 public class AMLMapViewState: ObservableObject {
-    /// The underlying `MGLMapView`
-    @Published public var mapView: MGLMapView?
+    /// The underlying `MLNMapView`
+    @Published public var mapView: MLNMapView?
 
     /// The current heading of the map in degrees.
     @Published public var heading: CLLocationDirection
@@ -21,7 +21,7 @@ public class AMLMapViewState: ObservableObject {
     @Published public var zoomLevel: Double
 
     /// The coordinate bounds of the currently displayed area of the map.
-    @Published public var bounds: MGLCoordinateBounds
+    @Published public var bounds: MLNCoordinateBounds
 
     /// The center coordinates of the currently displayed area of the map.
     @Published public var center: CLLocationCoordinate2D
@@ -30,7 +30,7 @@ public class AMLMapViewState: ObservableObject {
     @Published public var userLocation: CLLocationCoordinate2D?
 
     /// Features that are displayed on the map.
-    @Published public var features: [MGLPointFeature]
+    @Published public var features: [MLNPointFeature]
 
     /// The attribution string for the map data providers.
     @Published public var attribution: String?
@@ -40,11 +40,11 @@ public class AMLMapViewState: ObservableObject {
 
     /// Create an `AMLMapViewState` object to track state changes.
     /// - Parameters:
-    ///   - mapView: The underlying `MGLMapView`
+    ///   - mapView: The underlying `MLNMapView`
     ///   - heading: The current heading of the map in degrees. Default is `0` (North).
     ///   - zoomLevel: Current zoom level of the map. Default is `14`.
     ///   - bounds: The coordinate bounds of the currently displayed area of the map.
-    ///   Default is an empty `MGLCoordinateBounds`.
+    ///   Default is an empty `MLNCoordinateBounds`.
     ///   - center: The center coordinates of the currently displayed area of the map.
     ///   Default is an empty `CLLOcationCoordinate2D`.
     ///   - userLocation: The user's current location. Default is `nil`.
@@ -52,16 +52,16 @@ public class AMLMapViewState: ObservableObject {
     ///   - features: Features that are displayed on the map. Default is `[]`
     ///   - attribution: The attribution string for the map data providers. Default is `nil`.
     public init(
-        mapView: MGLMapView? = nil,
+        mapView: MLNMapView? = nil,
         heading: CLLocationDirection = 0,
         zoomLevel: Double = 14,
-        bounds: MGLCoordinateBounds = .init(),
+        bounds: MLNCoordinateBounds = .init(),
         center: CLLocationCoordinate2D = .init(
             latitude: 47.62246,
             longitude: -122.336775
         ),
         userLocation: CLLocationCoordinate2D? = nil,
-        features: [MGLPointFeature] = [],
+        features: [MLNPointFeature] = [],
         attribution: String? = nil
     ) {
         self.mapView = mapView

--- a/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper+Coordinator.swift
+++ b/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper+Coordinator.swift
@@ -6,18 +6,18 @@
 //
 
 import SwiftUI
-import Mapbox
+import MapLibre
 
-extension _MGLMapViewWrapper {
-    /// Coordinator class for `_MGLMapViewWrapper` that manages MGLMapViewDelegate methods.
-    final class Coordinator: NSObject, MGLMapViewDelegate {
-        var control: _MGLMapViewWrapper
+extension _MLNMapViewWrapper {
+    /// Coordinator class for `_MLNMapViewWrapper` that manages MLNMapViewDelegate methods.
+    final class Coordinator: NSObject, MLNMapViewDelegate {
+        var control: _MLNMapViewWrapper
 
-        init(_ control: _MGLMapViewWrapper) {
+        init(_ control: _MLNMapViewWrapper) {
             self.control = control
         }
 
-        func mapView(_ mapView: MGLMapView, regionDidChangeWith reason: MGLCameraChangeReason, animated: Bool) {
+        func mapView(_ mapView: MLNMapView, regionDidChangeWith reason: MLNCameraChangeReason, animated: Bool) {
             DispatchQueue.main.async {
                 self.control.zoomLevel = mapView.zoomLevel
                 self.control.bounds = mapView.visibleCoordinateBounds
@@ -26,12 +26,12 @@ extension _MGLMapViewWrapper {
             }
         }
 
-        func mapView(_ mapView: MGLMapView, didUpdate userLocation: MGLUserLocation?) {
+        func mapView(_ mapView: MLNMapView, didUpdate userLocation: MLNUserLocation?) {
             control.userLocation = userLocation?.coordinate
         }
 
-        func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-            if let source = style.sources.first as? MGLVectorTileSource {
+        func mapView(_ mapView: MLNMapView, didFinishLoading style: MLNStyle) {
+            if let source = style.sources.first as? MLNVectorTileSource {
                 let attribution = source.attributionInfos.first
                 control.attribution = attribution?.title.string ?? ""
             }
@@ -40,7 +40,7 @@ extension _MGLMapViewWrapper {
             setTapRecognizer()
         }
 
-        func mapView(_ mapView: MGLMapView, regionWillChangeAnimated animated: Bool) {
+        func mapView(_ mapView: MLNMapView, regionWillChangeAnimated animated: Bool) {
             if let calloutViewToRemove = mapView.subviews.first(where: { $0.tag == 42 }) {
                 mapView.willRemoveSubview(calloutViewToRemove)
                 calloutViewToRemove.removeFromSuperview()
@@ -50,12 +50,12 @@ extension _MGLMapViewWrapper {
 }
 
 // MARK: Private Configuration Methods
-extension _MGLMapViewWrapper.Coordinator {
+extension _MLNMapViewWrapper.Coordinator {
 
-    /// Add rendering layers to `MGLStyle`.
+    /// Add rendering layers to `MLNStyle`.
     ///
     /// - FeatureLayer: Features representing a point on the map.
-    /// Sourced through `features` property of `_MGLMapViewWrapper`.
+    /// Sourced through `features` property of `_MLNMapViewWrapper`.
     ///     - Identifier: `"aml_feature_style_layer"`
     ///     - Uses source identifier: `"aml_location_source"`
     ///     - Rendered image identifier: `"aml_feature"`
@@ -65,8 +65,8 @@ extension _MGLMapViewWrapper.Coordinator {
     ///     - Uses source identifier: `"aml_location_source"`
     /// - ClusterNumberLayer: Renders numbers representing the amount of features within a feature cluster.
     ///     - Identifier: `"aml_cluster_number_layer"`
-    /// - Parameter style: The `MGLStyle` that the layers will be added to.
-    private func setupRenderingLayers(for style: MGLStyle) {
+    /// - Parameter style: The `MLNStyle` that the layers will be added to.
+    private func setupRenderingLayers(for style: MLNStyle) {
         let locationSource = makeLocationSource()
         style.addSource(locationSource)
         let defaultImage = UIImage(
@@ -87,9 +87,9 @@ extension _MGLMapViewWrapper.Coordinator {
     }
 
     /// Create the location source used to source features in the subsequent layers.
-    /// - Returns: A `MGLShapeSource` with defined clustering options.
-    private func makeLocationSource() -> MGLShapeSource {
-        MGLShapeSource.init(
+    /// - Returns: A `MLNShapeSource` with defined clustering options.
+    private func makeLocationSource() -> MLNShapeSource {
+        MLNShapeSource.init(
             identifier: "aml_location_source",
             shape: nil,
             options:
@@ -103,9 +103,9 @@ extension _MGLMapViewWrapper.Coordinator {
 
     /// Create the layer that renders features on the map.
     /// - Parameter source: The layer's source.
-    /// - Returns: A `MGLSymbolStyleLayer` that will render features provided through the `source`.
-    private func makeFeatureLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
-        let featureLayer = MGLSymbolStyleLayer(identifier: "aml_feature_style_layer", source: source)
+    /// - Returns: A `MLNSymbolStyleLayer` that will render features provided through the `source`.
+    private func makeFeatureLayer(for source: MLNSource) -> MLNSymbolStyleLayer {
+        let featureLayer = MLNSymbolStyleLayer(identifier: "aml_feature_style_layer", source: source)
         featureLayer.iconImageName = NSExpression(forConstantValue: "aml_feature")
         featureLayer.iconIgnoresPlacement = NSExpression(forConstantValue: true)
         featureLayer.iconAllowsOverlap = NSExpression(forConstantValue: true)
@@ -115,27 +115,28 @@ extension _MGLMapViewWrapper.Coordinator {
 
     /// Create the layer that renders feature clusters on the map.
     /// - Parameter source: The layer's source. Generally the same as the feature layer's `source`.
-    /// - Returns: A `MGLCircleStyleLayer` that will render feature clusters provided through the `source`.
+    /// - Returns: A `MLNCircleStyleLayer` that will render feature clusters provided through the `source`.
     /// Clustering behavior defined through `ClusteringBehavior`.
-    private func makeClusterCircleLayer(for source: MGLSource) -> MGLCircleStyleLayer {
-        let clusterCircleLayer = MGLCircleStyleLayer(identifier: "aml_cluster_circle_layer", source: source)
-
+    private func makeClusterCircleLayer(for source: MLNSource) -> MLNCircleStyleLayer {
+        let clusterCircleLayer = MLNCircleStyleLayer(identifier: "aml_cluster_circle_layer", source: source)
         clusterCircleLayer.circleRadius = NSExpression(
-            format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'exponential', 10, %@)",
-            [
+            forMLNInterpolating: .zoomLevelVariable,
+            curveType: .exponential,
+            parameters: NSExpression(forConstantValue: 10),
+            stops: NSExpression(forConstantValue: [
                 control.clusteringBehavior.maximumZoomLevel + 2: 20,
                 control.clusteringBehavior.maximumZoomLevel + 4: 30,
                 control.clusteringBehavior.maximumZoomLevel + 6: 40,
                 control.clusteringBehavior.maximumZoomLevel + 8: 50,
                 control.clusteringBehavior.maximumZoomLevel + 9: 60
-            ]
+            ])
         )
         clusterCircleLayer.circleStrokeColor = NSExpression(forConstantValue: UIColor.white)
         clusterCircleLayer.circleStrokeWidth = NSExpression(forConstantValue: 4)
         clusterCircleLayer.circleColor = NSExpression(
-            format: "mgl_step:from:stops:(point_count, %@, %@)",
-            control.clusteringBehavior.clusterColor,
-            control.clusteringBehavior.clusterColorSteps
+            forMLNStepping: NSExpression(forKeyPath: "point_count"),
+            from: NSExpression(forConstantValue: control.clusteringBehavior.clusterColor),
+            stops: NSExpression(forConstantValue: control.clusteringBehavior.clusterColorSteps)
         )
         clusterCircleLayer.predicate = NSPredicate(format: "cluster == YES")
 
@@ -144,9 +145,9 @@ extension _MGLMapViewWrapper.Coordinator {
 
     /// Create the layer that renders numbers on the feature clusters on the map.
     /// - Parameter source: The layer's source. Generally the same as the cluster circle layer's `source`.
-    /// - Returns: A `MGLSymbolStyleLayer` that renders numbers on feature clusters provided through the `source`.
-    private func makeClusterNumberLayer(for source: MGLSource) -> MGLSymbolStyleLayer {
-        let clusterNumberLayer = MGLSymbolStyleLayer(identifier: "aml_cluster_number_layer", source: source)
+    /// - Returns: A `MLNSymbolStyleLayer` that renders numbers on feature clusters provided through the `source`.
+    private func makeClusterNumberLayer(for source: MLNSource) -> MLNSymbolStyleLayer {
+        let clusterNumberLayer = MLNSymbolStyleLayer(identifier: "aml_cluster_number_layer", source: source)
         clusterNumberLayer.text = NSExpression(format: "CAST(point_count, 'NSString')")
         clusterNumberLayer.textColor = NSExpression(forConstantValue: control.clusteringBehavior.clusterNumberColor)
         clusterNumberLayer.textFontNames = NSExpression(forConstantValue: ["Arial Bold"])
@@ -179,9 +180,9 @@ extension _MGLMapViewWrapper.Coordinator {
         ).first
         else { return }
 
-        if let tappedCluster = tappedFeature as? MGLPointFeatureCluster {
+        if let tappedCluster = tappedFeature as? MLNPointFeatureCluster {
             control.proxyDelegate.clusterTapped(control.mapView, tappedCluster)
-        } else if let tappedFeature = tappedFeature as? MGLPointFeature {
+        } else if let tappedFeature = tappedFeature as? MLNPointFeature {
             control.proxyDelegate.featureTapped(control.mapView, tappedFeature)
         }
     }

--- a/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper+ViewModifiers.swift
+++ b/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper+ViewModifiers.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 import CoreLocation
-import Mapbox
+import MapLibre
 import SwiftUI
 
-extension _MGLMapViewWrapper {
+extension _MLNMapViewWrapper {
     /// View modifier to enable showing the user's location on the map.
     ///
     /// To access the user's location, location access must be enabled in the app, and
     /// the user must choose to allow access.
     /// - Parameter showLocation: Enables showing the user's location on the map.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func showUserLocation(_ showLocation: Bool) -> _MGLMapViewWrapper {
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
+    func showUserLocation(_ showLocation: Bool) -> _MLNMapViewWrapper {
         mapView.showsUserLocation = showLocation
         return self
     }
@@ -37,8 +37,8 @@ extension _MGLMapViewWrapper {
     /// - Important:
     /// The minimum allowable zoom level is 0 and the maximum allowable zoom level is 22.
     /// Any value set below 0 or above 22 will revert to 0 or 22 accordingly.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func allowedZoomLevels(_ zoomLevels: ClosedRange<Double>) -> _MGLMapViewWrapper {
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
+    func allowedZoomLevels(_ zoomLevels: ClosedRange<Double>) -> _MLNMapViewWrapper {
         mapView.minimumZoomLevel = max(zoomLevels.lowerBound, 0)
         mapView.maximumZoomLevel = min(zoomLevels.upperBound, 22)
         return self
@@ -57,8 +57,8 @@ extension _MGLMapViewWrapper {
     /// - Parameter maxZoomLevel: The maximum zoom level allowed by the map.
     /// - Important:
     /// The maximum zoom level is 22. Any value set above 22 will revert to 22.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func maxZoomLevel(_ maxZoomLevel: Double) -> _MGLMapViewWrapper {
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
+    func maxZoomLevel(_ maxZoomLevel: Double) -> _MLNMapViewWrapper {
         mapView.maximumZoomLevel = min(maxZoomLevel, 22)
         return self
     }
@@ -76,16 +76,16 @@ extension _MGLMapViewWrapper {
     /// - Parameter minZoomLevel: The minimum zoom level allowed by the map.
     /// - Important:
     ///  The minimum allowable zoom level is 0. Any value set below 0 revert to 0.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func minZoomLevel(_ minZoomLevel: Double) -> _MGLMapViewWrapper {
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
+    func minZoomLevel(_ minZoomLevel: Double) -> _MLNMapViewWrapper {
         mapView.minimumZoomLevel = max(minZoomLevel, 0)
         return self
     }
 
-    /// Set the position of the compass on the `MGLMapView`.
-    /// - Parameter position: `MGLOrnamentPosition` defining the location.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
-    func compassPosition(_ position: MGLOrnamentPosition) -> _MGLMapViewWrapper {
+    /// Set the position of the compass on the `MLNMapView`.
+    /// - Parameter position: `MLNOrnamentPosition` defining the location.
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
+    func compassPosition(_ position: MLNOrnamentPosition) -> _MLNMapViewWrapper {
         mapView.compassViewPosition = position
         return self
     }
@@ -95,15 +95,15 @@ extension _MGLMapViewWrapper {
     /// The default implementation pans the feature to the center of the screen and presents an `AMLCalloutView`.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeature`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeature`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeature` as needed.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
     func featureTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeature: MGLPointFeature
+            _ mapView: MLNMapView,
+            _ pointFeature: MLNPointFeature
         ) -> Void
-    ) -> _MGLMapViewWrapper {
+    ) -> _MLNMapViewWrapper {
         proxyDelegate.featureTapped = implementation
         return self
     }
@@ -113,15 +113,15 @@ extension _MGLMapViewWrapper {
     /// The default implementation zooms in on the map.
     /// Defining an implementation here will override this behavior.
     ///
-    /// - Parameter implementation: Closure provided a `MGLMapView` and `MGLPointFeatureCluster`.
+    /// - Parameter implementation: Closure provided a `MLNMapView` and `MLNPointFeatureCluster`.
     /// Define your desired behavior on the `mapView` using information from the `pointFeatureCluster` as needed.
-    /// - Returns: An instance of `_MGLMapViewWrapper`.
+    /// - Returns: An instance of `_MLNMapViewWrapper`.
     func featureClusterTapped(
         _ implementation: @escaping (
-            _ mapView: MGLMapView,
-            _ pointFeatureCluster: MGLPointFeatureCluster
+            _ mapView: MLNMapView,
+            _ pointFeatureCluster: MLNPointFeatureCluster
         ) -> Void
-    ) -> _MGLMapViewWrapper {
+    ) -> _MLNMapViewWrapper {
         proxyDelegate.clusterTapped = implementation
         return self
     }

--- a/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper.swift
+++ b/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper.swift
@@ -8,19 +8,19 @@
 import SwiftUI
 import Amplify
 import AWSLocationGeoPlugin
-import Mapbox
+import MapLibre
 
-/// SwiftUI Wrapper for MGLMapView.
-internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:this type_name
+/// SwiftUI Wrapper for MLNMapView.
+internal struct _MLNMapViewWrapper: UIViewRepresentable { // swiftlint:disable:this type_name
 
-    /// Underlying MGLMapView.
-    let mapView: MGLMapView
+    /// Underlying MLNMapView.
+    let mapView: MLNMapView
 
     /// Current zoom level of the map
     @Binding var zoomLevel: Double
 
     /// The coordinate bounds of the currently displayed area of the map.
-    @Binding var bounds: MGLCoordinateBounds
+    @Binding var bounds: MLNCoordinateBounds
 
     /// The center coordinates of the currently displayed area of the map.
     @Binding var center: CLLocationCoordinate2D
@@ -32,7 +32,7 @@ internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
     @Binding var userLocation: CLLocationCoordinate2D?
 
     /// Features that are displayed on the map.
-    @Binding var features: [MGLPointFeature]
+    @Binding var features: [MLNPointFeature]
 
     /// The attribution string for the map data providers.
     @Binding var attribution: String?
@@ -43,10 +43,10 @@ internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
     /// Implementation definitions for user interactions with the map.
     let proxyDelegate: AMLMapView.ProxyDelegate // swiftlint:disable:this weak_delegate
 
-    /// Create a `_MGLMapViewWrapper`.
-    /// An internal SwiftUI wrapper View around MGLMapView.
+    /// Create a `_MLNMapViewWrapper`.
+    /// An internal SwiftUI wrapper View around MLNMapView.
     /// - Parameters:
-    ///   - mapView: The underlying MGLMapView.
+    ///   - mapView: The underlying MLNMapView.
     ///   - zoomLevel: Current zoom level of the map.
     ///   - bounds: The coordinate bounds of the currently displayed area of the map.
     ///   - center: The center coordinates of the currently displayed area of the map.
@@ -60,14 +60,14 @@ internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
     ///   - clusteringBehavior: The clustering behavior of the map.
     ///   - proxyDelegate: Implementation definitions for user interactions with the map.
     init(
-        mapView: MGLMapView,
+        mapView: MLNMapView,
         zoomLevel: Binding<Double>,
-        bounds: Binding<MGLCoordinateBounds>,
+        bounds: Binding<MLNCoordinateBounds>,
         center: Binding<CLLocationCoordinate2D>,
         heading: Binding<CLLocationDirection>,
         userLocation: Binding<CLLocationCoordinate2D?>,
         showUserLocation: Bool,
-        features: Binding<[MGLPointFeature]>,
+        features: Binding<[MLNPointFeature]>,
         attribution: Binding<String?>,
         featureImage: UIImage,
         clusteringBehavior: AMLMapView.ClusteringBehavior,
@@ -90,34 +90,35 @@ internal struct _MGLMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
         self.mapView.showsUserLocation = showUserLocation || userLocation.wrappedValue != nil
         self.mapView.style?.setImage(featureImage, forName: "aml_feature")
         self.mapView.attributionButton.isHidden = true
+        
     }
 
-    public func makeUIView(context: UIViewRepresentableContext<_MGLMapViewWrapper>) -> MGLMapView {
+    public func makeUIView(context: UIViewRepresentableContext<_MLNMapViewWrapper>) -> MLNMapView {
         mapView.delegate = context.coordinator
         return mapView
     }
 
-    public func updateUIView(_ uiView: MGLMapView, context: UIViewRepresentableContext<_MGLMapViewWrapper>) {
+    public func updateUIView(_ uiView: MLNMapView, context: UIViewRepresentableContext<_MLNMapViewWrapper>) {
         handleZoomUpdate(in: uiView)
         handleCameraUpdate(in: uiView)
         handleFeatureUpdate(in: uiView)
     }
 
-    private func handleFeatureUpdate(in mapView: MGLMapView) {
+    private func handleFeatureUpdate(in mapView: MLNMapView) {
         guard let clusterSource = mapView.style?
-                .source(withIdentifier: "aml_location_source") as? MGLShapeSource
+                .source(withIdentifier: "aml_location_source") as? MLNShapeSource
         else { return }
-        clusterSource.shape = MGLShapeCollectionFeature.init(shapes: features)
+        clusterSource.shape = MLNShapeCollectionFeature.init(shapes: features)
     }
 
-    private func handleCameraUpdate(in mapView: MGLMapView) {
+    private func handleCameraUpdate(in mapView: MLNMapView) {
         guard mapView.camera.heading != heading else { return }
         let camera = mapView.camera
         camera.heading = heading
         mapView.setCamera(camera, animated: true)
     }
 
-    private func handleZoomUpdate(in mapView: MGLMapView) {
+    private func handleZoomUpdate(in mapView: MLNMapView) {
         guard mapView.zoomLevel != zoomLevel else { return }
         mapView.setZoomLevel(zoomLevel, animated: true)
     }

--- a/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper.swift
+++ b/Sources/AmplifyMapLibreUI/MLNMapViewWrapper/_MLNMapViewWrapper.swift
@@ -90,7 +90,7 @@ internal struct _MLNMapViewWrapper: UIViewRepresentable { // swiftlint:disable:t
         self.mapView.showsUserLocation = showUserLocation || userLocation.wrappedValue != nil
         self.mapView.style?.setImage(featureImage, forName: "aml_feature")
         self.mapView.attributionButton.isHidden = true
-        
+
     }
 
     public func makeUIView(context: UIViewRepresentableContext<_MLNMapViewWrapper>) -> MLNMapView {

--- a/Sources/AmplifyMapLibreUI/SupportingViews/AMLCalloutUIView.swift
+++ b/Sources/AmplifyMapLibreUI/SupportingViews/AMLCalloutUIView.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import Mapbox
+import MapLibre
 
 /// Internal default callout view displayed when a user taps a feature.
 class AMLCalloutUIView: UIView {
@@ -27,8 +27,8 @@ class AMLCalloutUIView: UIView {
     /// Initializes an `AMLCalloutView` with information displayed from the feature.
     /// - Parameters:
     ///   - frame: The view's specified frame rectangle.
-    ///   - feature: The `MGLPointFeature` for the callout view.
-    init(frame: CGRect, feature: MGLPointFeature) {
+    ///   - feature: The `MLNPointFeature` for the callout view.
+    init(frame: CGRect, feature: MLNPointFeature) {
         super.init(frame: frame)
         configureView()
         configureSubviews()
@@ -36,7 +36,7 @@ class AMLCalloutUIView: UIView {
         setLabelText(for: feature)
     }
 
-    private func setLabelText(for feature: MGLPointFeature) {
+    private func setLabelText(for feature: MLNPointFeature) {
         nameLabel.text = feature.attributes["aml_display_label"] as? String
         addressLineOneLabel.text = feature.attributes["aml_display_addressLineOne"] as? String
         addressLineTwoLabel.text = feature.attributes["aml_display_addressLineTwo"] as? String

--- a/Tests/AmplifyMapLibreAdapterTests/AmplifyMapLibreAdapterTests.swift
+++ b/Tests/AmplifyMapLibreAdapterTests/AmplifyMapLibreAdapterTests.swift
@@ -8,15 +8,15 @@
 import XCTest
 @testable import AmplifyMapLibreAdapter
 import Amplify
-import Mapbox
+import MapLibre
 
 final class AmplifyMapLibreAdapterTests: XCTestCase {
-    var bounds: MGLCoordinateBounds!
+    var bounds: MLNCoordinateBounds!
 
     override func setUp() {
         let southwest = CLLocationCoordinate2D(latitude: 39.7382, longitude: -105.0042)
         let northeast = CLLocationCoordinate2D(latitude: 39.7682, longitude: -104.9765)
-        bounds = MGLCoordinateBounds(sw: southwest, ne: northeast)
+        bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
     }
 
     /// Test if register(sessionConfig:) registers AWSMapURLProtocol successfully.
@@ -35,15 +35,15 @@ final class AmplifyMapLibreAdapterTests: XCTestCase {
         XCTAssertTrue(configuration.protocolClasses?.first == AWSMapURLProtocol.self)
     }
 
-    /// Test if Geo.BoundingBox is correctly initiallized from MGLCoordinateBounds
+    /// Test if Geo.BoundingBox is correctly initiallized from MLNCoordinateBounds
     ///
-    /// - Given: MGLCoordinateBounds
+    /// - Given: MLNCoordinateBounds
     /// - When:
     ///    - I invoke Geo.BoundingBox(bounds)
     /// - Then:
     ///    - An instance of Geo.BoundingBox is initialized with the given bounds.
     ///
-    func testGeoBoundingBoxWithMGLCoordinateBounds() {
+    func testGeoBoundingBoxWithMLNCoordinateBounds() {
         let boundingBox = Geo.BoundingBox(bounds)
         XCTAssertEqual(boundingBox.northeast.latitude, bounds.ne.latitude)
         XCTAssertEqual(boundingBox.northeast.longitude, bounds.ne.longitude)
@@ -51,18 +51,18 @@ final class AmplifyMapLibreAdapterTests: XCTestCase {
         XCTAssertEqual(boundingBox.southwest.longitude, bounds.sw.longitude)
     }
 
-    /// Test if Geo.SearchArea is correctly initialized from MGLCoordinateBounds.
+    /// Test if Geo.SearchArea is correctly initialized from MLNCoordinateBounds.
     ///
-    /// - Given: MGLCoordinateBounds
+    /// - Given: MLNCoordinateBounds
     /// - When:
     ///    - I invoke Geo.SearchArea.within(bounds)
     /// - Then:
     ///    - An instance of Geo.SearchArea is initialized with the given bounds.
     ///
-    func testGeoSearchAreaWithMGLCoordinateBounds() {
+    func testGeoSearchAreaWithMLNCoordinateBounds() {
         let searchArea = Geo.SearchArea.within(bounds)
         guard case .within(let boundingBox) = searchArea else {
-            XCTFail("Failed to create Geo.SearchArea from MGLCoordinateBounds.")
+            XCTFail("Failed to create Geo.SearchArea from MLNCoordinateBounds.")
             return
         }
         XCTAssertEqual(boundingBox.northeast.latitude, bounds.ne.latitude)
@@ -71,18 +71,18 @@ final class AmplifyMapLibreAdapterTests: XCTestCase {
         XCTAssertEqual(boundingBox.southwest.longitude, bounds.sw.longitude)
     }
 
-    /// Test if MGLPointFeature is correctly initialized with a title and coordinates.
+    /// Test if MLNPointFeature is correctly initialized with a title and coordinates.
     ///
     /// - Given: A title String and CLLocationCoordinate2D.
     /// - When:
-    ///    - I invoke MGLPointFeature(title: title, coordinates: coordinates)
+    ///    - I invoke MLNPointFeature(title: title, coordinates: coordinates)
     /// - Then:
-    ///    - An instance of MGLPointFeature is initialized with the given title and coordinates.
+    ///    - An instance of MLNPointFeature is initialized with the given title and coordinates.
     ///
-    func testMGLPointFeatureWithTitleAndCoordinates() {
+    func testMLNPointFeatureWithTitleAndCoordinates() {
         let title = "Test"
         let coordinates = CLLocationCoordinate2D(latitude: 39.7682, longitude: -104.9765)
-        let feature = MGLPointFeature(title: title, coordinates: coordinates)
+        let feature = MLNPointFeature(title: title, coordinates: coordinates)
         XCTAssertEqual(feature.title, title)
         XCTAssertEqual(feature.coordinate.latitude, coordinates.latitude)
         XCTAssertEqual(feature.coordinate.longitude, coordinates.longitude)

--- a/Tests/AmplifyMapLibreUITests/AMLMapCompositeViewTestCase.swift
+++ b/Tests/AmplifyMapLibreUITests/AMLMapCompositeViewTestCase.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import XCTest
-import Mapbox
+import MapLibre
 @testable import AmplifyMapLibreAdapter
 @testable import AmplifyMapLibreUI
 
@@ -21,7 +21,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
     func testShowUserLocation() {
         // User supplied map
         do {
-            let mapView = MGLMapView()
+            let mapView = MLNMapView()
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .showUserLocation(true)
@@ -39,7 +39,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
     func testAllowedZoomLevels() {
         // User supplied map
         do {
-            let mapView = MGLMapView()
+            let mapView = MLNMapView()
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .allowedZoomLevels(5 ... 15)
@@ -60,7 +60,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
     func testMaxZoomLevel() {
         // User supplied map
         do {
-            let mapView = MGLMapView()
+            let mapView = MLNMapView()
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .maxZoomLevel(3)
@@ -79,7 +79,7 @@ class AMLMapCompositeViewTestCase: XCTestCase {
     func testMinZoomLevel() {
         // User supplied map
         do {
-            let mapView = MGLMapView()
+            let mapView = MLNMapView()
             let mapState = AMLMapViewState(mapView: mapView)
             let map = compositeView(with: mapState)
                 .minZoomLevel(14)

--- a/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
+++ b/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
@@ -99,7 +99,7 @@ final class AMLMapViewTestCase: XCTestCase {
     }
 }
 
-fileprivate extension Double {
+private extension Double {
     func rounded(places: Double) -> Double {
         let divisor = pow(10, places)
         return (self * divisor).rounded() / divisor

--- a/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
+++ b/Tests/AmplifyMapLibreUITests/AMLMapViewTestCase.swift
@@ -7,23 +7,23 @@
 
 import SwiftUI
 import XCTest
-import Mapbox
+import MapLibre
 @testable import AmplifyMapLibreAdapter
 @testable import AmplifyMapLibreUI
 
 final class AMLMapViewTestCase: XCTestCase {
 
-    var mglMapView: MGLMapView!
+    var mlnMapView: MLNMapView!
 
     override func setUp() {
-        mglMapView = .init()
+        mlnMapView = .init()
     }
 
     // MARK: View Modifier Test Cases
 
     // public func showUserLocation(_ showLocation: Bool) -> AMLMapView
     func testShowUserLocation() {
-        let mapView = AMLMapView(mapState: .init(mapView: mglMapView))
+        let mapView = AMLMapView(mapState: .init(mapView: mlnMapView))
         // `showUserLocation` defaults to false if `AMLMapView` is instantiated without a `userLocation`
         XCTAssertFalse(mapView.mapSettings.showUserLocation)
 
@@ -40,7 +40,7 @@ final class AMLMapViewTestCase: XCTestCase {
 
     // public func allowedZoomLevels(_ zoomLevels: ClosedRange<Double>) -> AMLMapView
     func testAllowedZoomLevels() {
-        let mapView = AMLMapView(mapState: .init(mapView: mglMapView))
+        let mapView = AMLMapView(mapState: .init(mapView: mlnMapView))
         // Test default behavior
         XCTAssertEqual(mapView.mapSettings.minZoomLevel, 0)
         XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 22)
@@ -76,7 +76,7 @@ final class AMLMapViewTestCase: XCTestCase {
 
     // public func maxZoomLevel(_ maxZoomLevel: Double) -> AMLMapView
     func testMaxZoomLevel() {
-        let mapView = AMLMapView(mapState: .init(mapView: mglMapView))
+        let mapView = AMLMapView(mapState: .init(mapView: mlnMapView))
             .maxZoomLevel(19)
         XCTAssertEqual(mapView.mapSettings.maxZoomLevel, 19)
 
@@ -88,7 +88,7 @@ final class AMLMapViewTestCase: XCTestCase {
 
     // public func minZoomLevel(_ minZoomLevel: Double) -> AMLMapView
     func testMinZoomLevel() {
-        let mapView = AMLMapView(mapState: .init(mapView: mglMapView))
+        let mapView = AMLMapView(mapState: .init(mapView: mlnMapView))
             .minZoomLevel(4)
         XCTAssertEqual(mapView.mapSettings.minZoomLevel, 4)
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ios-maplibre/issues/28
- https://github.com/aws-amplify/amplify-ios-maplibre/issues/22

**Description of changes:**
This PR does the following:
- Addresses the compilation error caused due to some AWS SDK for Swift renaming
- Upgrades to the latest MapLibre Native version, which moved away from OpenGL and now uses Metal
  - This solves crashes on startup that are seen when building with Xcode 15
  - Several internal renames were needed to accommodate this, mainly the `MGL -> MLN` prefix
- Removes the "NSExpression is forbidden" warning by tweaking the creation of said expressions
- Fixes an empty map being displayed due to a wrong formatting in the URL path inside our URLProtocol.
- Updates the `build_test` workflow to use a newer device and checkout action.

*Check points: (check or cross out if not relevant)*

- [X] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [X] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all targets using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
