### PR TITLE
fix: Fixing compilation issues with new Amplify version.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "99c72db23217c8944dda92a9be26f7c0d0d5de3f",
-          "version": "2.37.0"
+          "revision": "9a4ce09141d5045b8dfe55cb301b0691e3341a00",
+          "version": "2.41.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/awslabs/aws-crt-swift",
         "state": {
           "branch": null,
-          "revision": "0d0a0cf2e2cb780ceeceac190b4ede94f4f96902",
-          "version": "0.26.0"
+          "revision": "7b42e0343f28b3451aab20840dc670abd12790bd",
+          "version": "0.36.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "47922c05dd66be717c7bce424651a534456717b7",
-          "version": "0.36.2"
+          "revision": "828358a2c39d138325b0f87a2d813f4b972e5f4f",
+          "version": "1.0.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/smithy-lang/smithy-swift",
         "state": {
           "branch": null,
-          "revision": "8a5b0105c1b8a1d26a9435fb0af3959a7f5de578",
-          "version": "0.41.1"
+          "revision": "0ed3440f8c41e27a0937364d5035d2d4fefb8aa3",
+          "version": "0.71.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(
             name: "Amplify",
             url: "https://github.com/aws-amplify/amplify-swift.git",
-            .upToNextMajor(from: "2.2.0")
+            .upToNextMajor(from: "2.41.0")
         ),
 
         // MapLibre

--- a/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
+++ b/Sources/AmplifyMapLibreAdapter/AWSMapURLProtocol+GeoConfig.swift
@@ -8,13 +8,13 @@
 import Foundation
 import Amplify
 import AWSLocationGeoPlugin
-import AWSClientRuntime
 import InternalAmplifyCredentials
+import SmithyIdentity
 
 extension AWSMapURLProtocol {
     struct GeoConfig {
         let regionName: String
-        let credentialsProvider: CredentialsProviding
+        let identityResolver: any AWSCredentialIdentityResolver
         let hostName: String
 
         init?() {
@@ -25,7 +25,7 @@ extension AWSMapURLProtocol {
             guard let credentiaslProvider = plugin.authService as? AWSAuthCredentialsProviderBehavior else {
                 return nil
             }
-            self.credentialsProvider = credentiaslProvider.getCredentialsProvider()
+            self.identityResolver = credentiaslProvider.getCredentialIdentityResolver()
             self.regionName = plugin.pluginConfig.regionName
             self.hostName = "maps.geo.\(regionName).amazonaws.com"
         }


### PR DESCRIPTION
**Description of changes:**

This PR fixes the compilations issues coming from Amplify now using version 1.0.0 of the Swift SDK, since some types and parameters have have been renamed/relocated.

*Check points: (check or cross out if not relevant)*

- [ ] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [ ] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all targets using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
