### PR TITLE
chore(dependencies): upgrade Amplify to 2.53.2

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,4 +15,4 @@ jobs:
           persist-credentials: false
 
       - name: Build and test
-        run: xcodebuild test -scheme "AmplifyMapLibreAdapter-Package" -destination "platform=iOS Simulator,name=iPhone 15 Pro" | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        run: xcodebuild test -scheme "AmplifyMapLibreAdapter-Package" -destination "platform=iOS Simulator,name=iPhone 16 Pro" | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/amplify-swift.git",
         "state": {
           "branch": null,
-          "revision": "9a4ce09141d5045b8dfe55cb301b0691e3341a00",
-          "version": "2.41.0"
+          "revision": "67be15dc214b0674432a544a683615af792f09a3",
+          "version": "2.53.2"
         }
       },
       {
@@ -20,12 +20,21 @@
         }
       },
       {
+        "package": "async-http-client",
+        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "state": {
+          "branch": null,
+          "revision": "c464bf94eac4273cad7424307a5dc7e44e361905",
+          "version": "1.30.1"
+        }
+      },
+      {
         "package": "aws-crt-swift",
         "repositoryURL": "https://github.com/awslabs/aws-crt-swift",
         "state": {
           "branch": null,
-          "revision": "7b42e0343f28b3451aab20840dc670abd12790bd",
-          "version": "0.36.0"
+          "revision": "8241ad06622f7351e8843dfab6bbce14fe6bce5d",
+          "version": "0.54.2"
         }
       },
       {
@@ -33,8 +42,17 @@
         "repositoryURL": "https://github.com/awslabs/aws-sdk-swift.git",
         "state": {
           "branch": null,
-          "revision": "828358a2c39d138325b0f87a2d813f4b972e5f4f",
-          "version": "1.0.0"
+          "revision": "61d0ab5b429599f22c44b71b0737f030dc82f76b",
+          "version": "1.6.7"
+        }
+      },
+      {
+        "package": "grpc-swift",
+        "repositoryURL": "https://github.com/grpc/grpc-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "8c5e99d0255c373e0330730d191a3423c57373fb",
+          "version": "1.24.2"
         }
       },
       {
@@ -47,12 +65,30 @@
         }
       },
       {
+        "package": "opentelemetry-swift",
+        "repositoryURL": "https://github.com/open-telemetry/opentelemetry-swift",
+        "state": {
+          "branch": null,
+          "revision": "6a2c29d53ff0b543b551b2221538bd3d0206c6d6",
+          "version": "1.15.0"
+        }
+      },
+      {
+        "package": "Opentracing",
+        "repositoryURL": "https://github.com/undefinedlabs/opentracing-objc",
+        "state": {
+          "branch": null,
+          "revision": "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+          "version": "0.5.2"
+        }
+      },
+      {
         "package": "smithy-swift",
         "repositoryURL": "https://github.com/smithy-lang/smithy-swift",
         "state": {
           "branch": null,
-          "revision": "0ed3440f8c41e27a0937364d5035d2d4fefb8aa3",
-          "version": "0.71.0"
+          "revision": "0f3fb709fd034ad4b7a19567858571d08a5f4cbe",
+          "version": "0.175.0"
         }
       },
       {
@@ -65,12 +101,174 @@
         }
       },
       {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "swift-distributed-tracing",
+        "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
+        "state": {
+          "branch": null,
+          "revision": "baa932c1336f7894145cbaafcd34ce2dd0b77c97",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "package": "swift-http-structured-headers",
+        "repositoryURL": "https://github.com/apple/swift-http-structured-headers.git",
+        "state": {
+          "branch": null,
+          "revision": "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "package": "swift-http-types",
+        "repositoryURL": "https://github.com/apple/swift-http-types.git",
+        "state": {
+          "branch": null,
+          "revision": "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+          "version": "1.5.1"
+        }
+      },
+      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
           "revision": "9cb486020ebf03bfa5b5df985387a14a98744537",
           "version": "1.6.1"
+        }
+      },
+      {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "e3d5c560e0a6bfa391a00e857aa28ad52a41fe8d",
+          "version": "2.92.1"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "f1f6f772198bee35d99dd145f1513d8581a54f2c",
+          "version": "1.26.0"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
+          "version": "1.39.0"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "173cc69a058623525a58ae6710e2f5727c663793",
+          "version": "2.36.0"
+        }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "60c3e187154421171721c1a38e800b390680fb5d",
+          "version": "1.26.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "state": {
+          "branch": null,
+          "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "c169a5744230951031770e27e475ff6eefe51f9d",
+          "version": "1.33.3"
+        }
+      },
+      {
+        "package": "swift-service-context",
+        "repositoryURL": "https://github.com/apple/swift-service-context.git",
+        "state": {
+          "branch": null,
+          "revision": "1983448fefc717a2bc2ebde5490fe99873c5b8a6",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+          "version": "1.6.3"
+        }
+      },
+      {
+        "package": "Thrift",
+        "repositoryURL": "https://github.com/undefinedlabs/Thrift-Swift",
+        "state": {
+          "branch": null,
+          "revision": "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+          "version": "1.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(
             name: "Amplify",
             url: "https://github.com/aws-amplify/amplify-swift.git",
-            .upToNextMajor(from: "2.41.0")
+            .upToNextMajor(from: "2.53.2")
         ),
 
         // MapLibre


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates the dependency on Amplify Swift in order to upgrade the transitive dependency on the AWS Swift SDK, which had a reported security problem via dependabot:
https://github.com/aws-amplify/amplify-ios-maplibre/security/dependabot/1

*Check points: (check or cross out if not relevant)*

- [ ] Ran swiftformat (from repository root): ```swiftformat Sources Tests```
- [ ] Ran swiftlint (from repository root): ```swiftlint Sources Tests``` and addressed all violations.
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all targets using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
