### PR TITLE
chore(deps): bump SwiftNIO family to patched versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -119,6 +119,24 @@
         }
       },
       {
+        "package": "swift-asn1",
+        "repositoryURL": "https://github.com/apple/swift-asn1.git",
+        "state": {
+          "branch": null,
+          "revision": "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+          "version": "1.7.1"
+        }
+      },
+      {
+        "package": "swift-async-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-async-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+          "version": "1.1.3"
+        }
+      },
+      {
         "package": "swift-atomics",
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
@@ -128,12 +146,30 @@
         }
       },
       {
+        "package": "swift-certificates",
+        "repositoryURL": "https://github.com/apple/swift-certificates.git",
+        "state": {
+          "branch": null,
+          "revision": "bde8ca32a096825dfce37467137c903418c1893d",
+          "version": "1.19.1"
+        }
+      },
+      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
           "revision": "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
           "version": "1.3.0"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+          "version": "4.5.0"
         }
       },
       {
@@ -168,8 +204,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "9cb486020ebf03bfa5b5df985387a14a98744537",
-          "version": "1.6.1"
+          "revision": "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+          "version": "1.13.2"
         }
       },
       {
@@ -186,8 +222,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "e3d5c560e0a6bfa391a00e857aa28ad52a41fe8d",
-          "version": "2.92.1"
+          "revision": "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+          "version": "2.101.0"
         }
       },
       {
@@ -195,8 +231,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f1f6f772198bee35d99dd145f1513d8581a54f2c",
-          "version": "1.26.0"
+          "revision": "d2eeec0339074034f11a040a74aa2a341a2c4506",
+          "version": "1.34.1"
         }
       },
       {
@@ -204,8 +240,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
-          "version": "1.39.0"
+          "revision": "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+          "version": "1.44.0"
         }
       },
       {
@@ -251,6 +287,15 @@
           "branch": null,
           "revision": "1983448fefc717a2bc2ebde5490fe99873c5b8a6",
           "version": "1.2.1"
+        }
+      },
+      {
+        "package": "swift-service-lifecycle",
+        "repositoryURL": "https://github.com/swift-server/swift-service-lifecycle.git",
+        "state": {
+          "branch": null,
+          "revision": "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+          "version": "2.11.0"
         }
       },
       {


### PR DESCRIPTION
## What
Bumps the transitive **SwiftNIO-family** dependencies pinned in `Package.resolved` to their patched versions, resolving open Dependabot security alerts.

| Package | Before | After | Advisory severity |
|---|---|---|---|
| swift-nio | 2.92.1 | **2.101.0** | High — resolved |
| swift-nio-extras | 1.26.0 | **1.34.1** | Medium — resolved |
| swift-nio-http2 | 1.39.0 | **1.44.0** | Low — see note below |

## Why
These packages are pulled in **transitively** (via amplify-swift → aws-sdk-swift / smithy-swift). Bumping the umbrella dependency alone does **not** pull patched SwiftNIO versions (the resolver keeps the existing in-range pins), so the lockfile is updated directly. The change is confined to `Package.resolved` — no source, manifest, or native code changes.

## Note on swift-nio-http2 (1.44.0 vs 1.44.1)
The Dependabot advisory **GHSA-4px2-pw77-vc85 / CVE-2026-28898** lists the patched version as `1.44.1`, but **that tag has not been published by Apple** — `1.44.0` is the latest release. Apple's official SwiftNIO security release identifies **1.44.0 as the fix** ("SwiftNIO 2.100.0, SwiftNIO HTTP/2 1.44.0, SwiftNIO Extras 1.34.1"). This PR pins http2 to the genuinely-patched `1.44.0`. GitHub's low-severity alert may continue to show "open" until its advisory metadata is corrected or `1.44.1` ships, at which point it can be dismissed as already-fixed.

## Validation
`swift package resolve` succeeds cleanly. No application or native code is touched.
